### PR TITLE
Fixes for Row::SDot and RowBlockContainer::{Save,Load}

### DIFF
--- a/include/dmlc/data.h
+++ b/include/dmlc/data.h
@@ -117,6 +117,7 @@ class Row {
         sum += weight[index[i]] * value[i];
       }
     }
+    return sum;
   }
 };
 

--- a/src/data/row_block.h
+++ b/src/data/row_block.h
@@ -154,16 +154,20 @@ inline void
 RowBlockContainer<IndexType>::Save(Stream *fo) const {
   fo->Write(offset);
   fo->Write(label);
+  fo->Write(weight);
   fo->Write(index);
   fo->Write(value);
+  fo->Write(&max_index, sizeof(IndexType));
 }
 template<typename IndexType>
 inline bool
 RowBlockContainer<IndexType>::Load(Stream *fi) {
   if (!fi->Read(&offset)) return false;
   CHECK(fi->Read(&label)) << "Bad RowBlock format";
-  CHECK(fi->Read(&value)) << "Bad RowBlock format";
+  CHECK(fi->Read(&weight)) << "Bad RowBlock format";
   CHECK(fi->Read(&index)) << "Bad RowBlock format";
+  CHECK(fi->Read(&value)) << "Bad RowBlock format";
+  CHECK(fi->Read(&max_index, sizeof(IndexType))) << "Bad RowBlock format";
   return true;
 }
 }  // namespace data


### PR DESCRIPTION
This PR fixes two small bugs that Krishna and I found:
- The first is that the function Row::SDot computes the dot product but does not return the value. 
- The second is that the functions RowBlockContainer::{Save,Load} did not save and load the RowBlockContainer members in the same order (so it looked like garbage was being loaded). 
- We also updated the RowBlockContainer::{Save,Load} functions to also save the row weights and the maximum index in the row block.