### PR TITLE
Added DMLC_DECLARE_TRAITS(is_pod, int8_t, true);

### DIFF
--- a/include/dmlc/type_traits.h
+++ b/include/dmlc/type_traits.h
@@ -47,6 +47,7 @@ struct has_saveload {
 //! \cond Doxygen_Suppress
 // declare special traits when C++11 is not available
 #if DMLC_USE_CXX11 == 0
+DMLC_DECLARE_TRAITS(is_pod, char, true);
 DMLC_DECLARE_TRAITS(is_pod, int8_t, true);
 DMLC_DECLARE_TRAITS(is_pod, int16_t, true);
 DMLC_DECLARE_TRAITS(is_pod, int32_t, true);


### PR DESCRIPTION
Fixes compilation on g++-4.8 and clang++-3.5.