### PR TITLE
[disallow-copy-and-assign-fix] bug fix under older C++

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -71,7 +71,7 @@
 #  else
 #    define DISALLOW_COPY_AND_ASSIGN(T) \
        T(T const&); \
-       T& operator=(T const&) = delete
+       T& operator=(T const&)
 #  endif
 #endif
 


### PR DESCRIPTION
Sorry I thought I fixed this but turns out I didn't.

There is no `delete` keyword when C++11 is not available