### PR TITLE
[concurrency-fix-for-gcc-4.8] member initialization doesn't work on G++ 4.8

### DIFF
--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -46,7 +46,7 @@ class Spinlock {
 template <typename T>
 class ConcurrentBlockingQueue {
  public:
-  ConcurrentBlockingQueue() = default;
+  ConcurrentBlockingQueue();
   ~ConcurrentBlockingQueue() = default;
   /*!
    * \brief Push element into the queue.
@@ -83,7 +83,7 @@ class ConcurrentBlockingQueue {
  private:
   std::mutex mutex_;
   std::condition_variable cv_;
-  std::atomic<bool> exit_now_{false};
+  std::atomic<bool> exit_now_;
   std::list<T> queue_;
   /*!
    * \brief Disable copy and move.
@@ -99,6 +99,9 @@ inline void Spinlock::lock() noexcept {
 inline void Spinlock::unlock() noexcept {
   lock_.clear(std::memory_order_release);
 }
+
+template <typename T>
+ConcurrentBlockingQueue<T>::ConcurrentBlockingQueue() : exit_now_{false} {}
 
 template <typename T>
 template <typename E>


### PR DESCRIPTION
I don't know why but the old syntax doesn't work on my G++ 4.8. I had to revert to the old way.

Please review and see if it breaks anything.