### PR TITLE
windows compatibility

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -82,10 +82,12 @@
 #define fopen64 std::fopen
 #endif
 #ifdef _MSC_VER
+#if _MSC_VER < 1900
 // NOTE: sprintf_s is not equivalent to snprintf,
 // they are equivalent when success, which is sufficient for our case
 #define snprintf sprintf_s
 #define vsnprintf vsprintf_s
+#endif
 #else
 #ifdef _FILE_OFFSET_BITS
 #if _FILE_OFFSET_BITS == 32

--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -21,7 +21,13 @@ namespace dmlc {
  */
 class Spinlock {
  public:
-  Spinlock() = default;
+#ifdef _MSC_VER
+   Spinlock() {
+     lock_.clear();
+   }
+#else
+   Spinlock() = default;
+#endif
   ~Spinlock() = default;
   /*!
    * \brief Acquire lock.
@@ -33,7 +39,11 @@ class Spinlock {
   inline void unlock() noexcept;
 
  private:
+#ifdef _MSC_VER
+   std::atomic_flag lock_;
+#else
   std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
+#endif
   /*!
    * \brief Disable copy and move.
    */

--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -40,7 +40,7 @@ class Spinlock {
 
  private:
 #ifdef _MSC_VER
-   std::atomic_flag lock_;
+  std::atomic_flag lock_;
 #else
   std::atomic_flag lock_ = ATOMIC_FLAG_INIT;
 #endif

--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -22,11 +22,11 @@ namespace dmlc {
 class Spinlock {
  public:
 #ifdef _MSC_VER
-   Spinlock() {
-     lock_.clear();
-   }
+  Spinlock() {
+    lock_.clear();
+  }
 #else
-   Spinlock() = default;
+  Spinlock() = default;
 #endif
   ~Spinlock() = default;
   /*!


### PR DESCRIPTION
It's a bug of Visual Studio. See http://stackoverflow.com/questions/19657222/how-do-i-initialise-an-atomic-flag-variable-if-it-is-a-member-of-a-class .