### PR TITLE
add (true) to match the macro noexcept(a)

### DIFF
--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -32,11 +32,11 @@ class Spinlock {
   /*!
    * \brief Acquire lock.
    */
-  inline void lock() noexcept;
+  inline void lock() noexcept(true);
   /*!
    * \brief Release lock.
    */
-  inline void unlock() noexcept;
+  inline void unlock() noexcept(true);
 
  private:
 #ifdef _MSC_VER
@@ -125,12 +125,12 @@ class ConcurrentBlockingQueue {
   DISALLOW_COPY_AND_ASSIGN(ConcurrentBlockingQueue);
 };
 
-inline void Spinlock::lock() noexcept {
+inline void Spinlock::lock() noexcept(true) {
   while (lock_.test_and_set(std::memory_order_acquire)) {
   }
 }
 
-inline void Spinlock::unlock() noexcept {
+inline void Spinlock::unlock() noexcept(true) {
   lock_.clear(std::memory_order_release);
 }
 


### PR DESCRIPTION
Visual Studio 2013 do not support `noexcept` feature. In `logging.h` there is a macro defined as 
```C++
#if defined(_MSC_VER) && _MSC_VER < 1900
#define noexcept(a)
#endif
```
But the keyword `noexcept` single do not match this macro. So I add the default parameter `(true)` after `noexcept`.