### PR TITLE
Fix handling of LD_LIBRARY_PATH

### DIFF
--- a/tracker/dmlc_yarn.py
+++ b/tracker/dmlc_yarn.py
@@ -160,8 +160,8 @@ def yarn_submit(nworker, nserver, pass_env):
             libcxx = args.ship_libcxx + '/libstdc++.so'
         fset.add(libcxx)
         # update local LD_LIBRARY_PATH
-        if 'LD_LIBRARY_PATH' in env:
-            env['LD_LIBRARY_PATH'] = libcxx + ':' + env['LD_LIBRARY_PATH']
+        old_LD_LIBRARY_PATH = env['LD_LIBRARY_PATH'] if 'LD_LIBRARY_PATH' in env else ''
+        env['LD_LIBRARY_PATH'] = args.ship_libcxx + ':' + old_LD_LIBRARY_PATH
 
     env['DMLC_CPU_VCORES'] = str(args.vcores)
     env['DMLC_MEMORY_MB'] = str(args.memory_mb)

--- a/yarn/run_hdfs_prog.py
+++ b/yarn/run_hdfs_prog.py
@@ -42,7 +42,8 @@ if 'DMLC_HDFS_OPTS' in env:
 elif 'LIBHDFS_OPTS' not in env:
     env['LIBHDFS_OPTS'] = '--Xmx128m'
 
-env['LD_LIBRARY_PATH'] = '${LD_LIBRARY_PATH}:' + (':'.join(lpath)) 
+old_LD_LIBRARY_PATH = env['LD_LIBRARY_PATH'] if 'LD_LIBRARY_PATH' in env else ''
+env['LD_LIBRARY_PATH'] = old_LD_LIBRARY_PATH + ':' + ':'.join(lpath)
 
 ret = subprocess.call(args = sys.argv[1:], env = env)
 sys.exit(ret)

--- a/yarn/src/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
+++ b/yarn/src/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
@@ -365,8 +365,9 @@ public class ApplicationMaster {
         env.put("CLASSPATH", cpath.toString());
         //LOG.info("CLASSPATH =" + cpath.toString());
         // setup LD_LIBARY_PATH path for libhdfs
+        String oldLD_LIBRARY_PATH = System.getenv("LD_LIBRARY_PATH");
         env.put("LD_LIBRARY_PATH",
-                "${LD_LIBRARY_PATH}:$HADOOP_HDFS_HOME/lib/native:$JAVA_HOME/jre/lib/amd64/server");
+                oldLD_LIBRARY_PATH == null ? "" : oldLD_LIBRARY_PATH + ":$HADOOP_HDFS_HOME/lib/native:$JAVA_HOME/jre/lib/amd64/server");
         env.put("PYTHONPATH", "${PYTHONPATH}:.");
         // inherit all rabit variables
         for (Map.Entry<String, String> e : System.getenv().entrySet()) {

--- a/yarn/src/org/apache/hadoop/yarn/dmlc/Client.java
+++ b/yarn/src/org/apache/hadoop/yarn/dmlc/Client.java
@@ -197,6 +197,9 @@ public class Client {
             if (e.getKey() == "LIBHDFS_OPTS") {
                 env.put(e.getKey(), e.getValue());
             }
+            if (e.getKey().equals("LD_LIBRARY_PATH")) {
+                env.put(e.getKey(), e.getValue());
+            }
         }
         LOG.debug(env);
         return env;


### PR DESCRIPTION
There were a number of issues preventing `LD_LIBRARY_PATH` from being passed correctly in yarn. Among other things, this prevented the `--ship-libcxx` option in `dmlc_yarn.py` from working correctly.