### PR TITLE
Fix ld error when building with glog.

### DIFF
--- a/make/dmlc.mk
+++ b/make/dmlc.mk
@@ -65,6 +65,7 @@ endif
 
 ifeq ($(USE_GLOG), 1)
 	DMLC_CFLAGS += -DDMLC_USE_GLOG=1
+	DMLC_LDFLAGS += -lglog
 endif
 
 ifeq ($(USE_AZURE),1)


### PR DESCRIPTION
When compiling wormhole with GLOG enabled, 
`make xgboost USE_HDFS=1 dmlc=~/d/wormhole/repo/dmlc-core USE_GLOG=1`
it produces error messages as below shows. This can be fixed by add `-lgflags` in `dmlc.mk`  in dmlc-core repo.
```
make[1]: Entering directory `/home/zork/dev-pla/wormhole/repo/xgboost'
g++ -Wall -O3 -msse2  -Wno-unknown-pragmas -funroll-loops -fopenmp -fPIC -fPIC -o xgboost updater.o gbm.o io.o main.o subtree/rabit/lib/librabit.a /home/zork/d/wormhole/repo
/dmlc-core/libdmlc.a -pthread -lm -lrt -fopenmp -lrt -L/home/zork/sys/hadoop-2.6.0/lib/native -lhdfs -L/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server -ljvm -Wl,-rpat
h=/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server
/home/zork/d/wormhole/repo/dmlc-core/libdmlc.a(io.o): In function `dmlc::io::FileSystem::GetInstance(std::string const&)':
io.cc:(.text+0x87): undefined reference to `google::LogMessageFatal::LogMessageFatal(char const*, int)'
io.cc:(.text+0x8f): undefined reference to `google::LogMessage::stream()'
io.cc:(.text+0xa6): undefined reference to `google::LogMessageFatal::~LogMessageFatal()'
io.cc:(.text+0x1be): undefined reference to `google::LogMessageFatal::LogMessageFatal(char const*, int)'
io.cc:(.text+0x1c6): undefined reference to `google::LogMessage::stream()'
io.cc:(.text+0x23f): undefined reference to `google::LogMessageFatal::LogMessageFatal(char const*, int)'
io.cc:(.text+0x247): undefined reference to `google::LogMessage::stream()'
/home/zork/d/wormhole/repo/dmlc-core/libdmlc.a(io.o): In function `dmlc::InputSplit::Create(char const*, unsigned int, unsigned int, char const*)':
io.cc:(.text+0x1615): undefined reference to `google::LogMessageFatal::LogMessageFatal(char const*, int)'
io.cc:(.text+0x161d): undefined reference to `google::LogMessage::stream()'
```


