### PR TITLE
Some minor patches to improve S3 reliability:

### DIFF
--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -418,13 +418,13 @@ int CURLReadStreamBase::FillBuffer(size_t nwant) {
   do {
     int msgq = 0;
     m = curl_multi_info_read(mcurl_, &msgq);
-    if(m && (m->msg == CURLMSG_DONE)) {
+    if (m && (m->msg == CURLMSG_DONE)) {
       if (m->data.result != CURLE_OK) {
         LOG(INFO) << "request failed with error "
                   << curl_easy_strerror(m->data.result);
       }
     }
-  } while(m);
+  } while (m);
 
   return nrun;
 }

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -16,9 +16,6 @@ namespace io {
 /*! \brief AWS S3 filesystem */
 class S3FileSystem : public FileSystem {
  public:
-  /*! \brief constructor */
-  S3FileSystem() = default;
-
   /*! \brief destructor */
   virtual ~S3FileSystem() {}
 

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -16,8 +16,21 @@ namespace io {
 /*! \brief AWS S3 filesystem */
 class S3FileSystem : public FileSystem {
  public:
+  /*! \brief constructor */
+  S3FileSystem() = default;
+
   /*! \brief destructor */
   virtual ~S3FileSystem() {}
+
+  /*!
+   * \brief Sets AWS access credentials
+   * \param aws_access_id The AWS Access Key ID
+   * \param aws_secret_key The AWS Secret Key
+   * \return the information about the file
+   */
+  void SetCredentials(const std::string& aws_access_id,
+                      const std::string& aws_secret_key);
+
   /*!
    * \brief get information about a path
    * \param path the path to the file


### PR DESCRIPTION
 - CURL_NOSIGNAL should be set when used in a multithreaded setting
 - Get better errors when curl_multi is used
 - Add an explicit Close() method call to the writestream
 - Add an explicit SetCredential method
 - Add support for creation of 0 byte files