### PR TITLE
support hdfs accessing across different clusters

### DIFF
--- a/src/io/filesys.h
+++ b/src/io/filesys.h
@@ -75,13 +75,13 @@ struct FileInfo {
 class FileSystem {
  public:
   /*!
-   * \brief get singleton of filesystem instance according to protocol
-   * \param protocol can be s3://, hdfs://, file://,
+   * \brief get singleton of filesystem instance according to URI
+   * \param path can be s3://..., hdfs://..., file://...,
    *            empty string(will return local)
    * \return a corresponding filesystem, report error if
    *         we cannot find a matching system
    */
-  static FileSystem *GetInstance(const std::string &protocol);
+  static FileSystem *GetInstance(const URI &path);
   /*! \brief virtual destructor */
   virtual ~FileSystem() {}
   /*!

--- a/src/io/hdfs_filesys.cc
+++ b/src/io/hdfs_filesys.cc
@@ -89,8 +89,7 @@ class HDFSStream : public SeekStream {
   hdfsFile fp_;
 };
 
-HDFSFileSystem::HDFSFileSystem(void) {
-  namenode_ = "default";
+HDFSFileSystem::HDFSFileSystem(const std::string &namenode): namenode_(namenode) {
   fs_ = hdfsConnect(namenode_.c_str(), 0);
   if (fs_ == NULL) {
     LOG(FATAL) << "Failed to load HDFS-configuration:";
@@ -108,6 +107,20 @@ HDFSFileSystem::~HDFSFileSystem(void) {
       LOG(FATAL) << "HDFSStream.hdfsDisconnect Error:" << strerror(errsv);
     }
   }
+}
+
+void HDFSFileSystem::ResetNamenode(const std::string &namenode) {
+  if (hdfsDisconnect(fs_) != 0) {
+    int errsv = errno;
+    LOG(FATAL) << "HDFSStream.hdfsDisconnect Error: " << strerror(errsv);
+  }
+
+  namenode_ = namenode;
+  fs_ = hdfsConnect(namenode_.c_str(), 0);
+  if (fs_ == NULL) {
+    LOG(FATAL) << "Failed to load HDFS-configuration: " << namenode_.c_str();
+  }
+  ref_counter_[0] = 1;
 }
 
 inline FileInfo ConvertPathInfo(const URI &path, const hdfsFileInfo &info) {

--- a/src/io/hdfs_filesys.h
+++ b/src/io/hdfs_filesys.h
@@ -55,14 +55,20 @@ class HDFSFileSystem : public FileSystem {
    * \brief get a singleton of HDFSFileSystem when needed
    * \return a singleton instance
    */
-  inline static HDFSFileSystem *GetInstance(void) {
-    static HDFSFileSystem instance;
+  inline static HDFSFileSystem *GetInstance(const std::string &namenode = "default") {
+    static HDFSFileSystem instance(namenode);
+    // switch to another hdfs
+    if (namenode != "default" && instance.namenode_ != namenode) {
+      instance.ResetNamenode(namenode);
+    }
     return &instance;
   }
 
  private:
   /*! \brief constructor */
-  HDFSFileSystem();
+  HDFSFileSystem(const std::string &namenode);
+  /*! \brief switch to another hdfs cluster */
+  void ResetNamenode(const std::string &namenode);
   /*! \brief namenode address */
   std::string namenode_;
   /*! \brief hdfs handle */

--- a/src/io/hdfs_filesys.h
+++ b/src/io/hdfs_filesys.h
@@ -66,7 +66,7 @@ class HDFSFileSystem : public FileSystem {
 
  private:
   /*! \brief constructor */
-  HDFSFileSystem(const std::string &namenode);
+  explicit HDFSFileSystem(const std::string &namenode);
   /*! \brief switch to another hdfs cluster */
   void ResetNamenode(const std::string &namenode);
   /*! \brief namenode address */

--- a/test/filesys_test.cc
+++ b/test/filesys_test.cc
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   using namespace dmlc::io;
   if (!strcmp(argv[1], "ls")) {
     URI path(argv[2]);
-    FileSystem *fs = FileSystem::GetInstance(path.protocol);
+    FileSystem *fs = FileSystem::GetInstance(path);
     std::vector<FileInfo> info;
     fs->ListDirectory(path, &info);
     for (size_t i = 0; i < info.size(); ++i) {
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
   }
   if (!strcmp(argv[1], "cat")) {
     URI path(argv[2]);
-    FileSystem *fs = FileSystem::GetInstance(path.protocol);
+    FileSystem *fs = FileSystem::GetInstance(path);
     dmlc::Stream *fp = fs->OpenForRead(path);
     char buf[32];
     while (true) {


### PR DESCRIPTION
At present, the dmlc-core only support default HDFS cluster accessing. However, we often need to access multiple HDFS clusters for data and model respectively in many different scenarios. So this patch aims to support hdfs accessing across different clusters. We can config the data or model througth absolute path,  such as:

data=hdfs://host:port/path/to/data
model_out=hdfs://otherhost:otherport/path/to/model
