### PR TITLE
Added HDFS support for cmake. This works with CDH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.7)
 
 project(dmlccore C CXX)
 
@@ -18,9 +18,10 @@ include_directories("include")
 set(dmlccore_LINKER_LIBS "")
 # HDFS configurations
 if(USE_HDFS)
- find_package(HDF5 COMPONENTS C CXX HL REQUIRED)
- include_directories(SYSTEM ${HDF5_INCLUDE_DIRS} ${HDF5_HL_INCLUDE_DIR})
- list(APPEND dmlccore_LINKER_LIBS ${HDF5_LIBRARIES})
+ find_package(HDFS REQUIRED)
+ find_package(JNI REQUIRED)
+ include_directories(${HDFS_INCLUDE_DIR})
+ list(APPEND dmlccore_LINKER_LIBS ${HDFS_LIBRARIES} ${JAVA_JVM_LIBRARY})
  add_definitions(-DDMLC_USE_HDFS=1)
 else()
  add_definitions(-DDMLC_USE_HDFS=0)
@@ -30,15 +31,15 @@ if(USE_S3)
  find_package(CURL REQUIRED)
  include_directories(SYSTEM ${CURL_INCLUDE_DIR})
  list(APPEND dmlccore_LINKER_LIBS ${CURL_LIBRARY})
- 
+
  find_package(OpenSSL REQUIRED)
  include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
  list(APPEND dmlccore_LINKER_LIBS ${OPENSSL_LIBRARY})
- 
+
  find_package(CRYPTO REQUIRED)
  include_directories(SYSTEM ${CRYPTO_INCLUDE_DIR})
  list(APPEND dmlccore_LINKER_LIBS ${CRYPTO_LIBRARY})
- 
+
  add_definitions(-DDMLC_USE_S3=1)
 else()
  add_definitions(-DDMLC_USE_S3=0)
@@ -65,7 +66,7 @@ else(MSVC)
   check_cxx_compiler_flag("-std=c++0x"    SUPPORT_CXX0X)
   check_cxx_compiler_flag("-msse2"        SUPPORT_MSSE2)
   set(CMAKE_C_FLAGS "-O3 -Wall -msse2 -Wno-unknown-pragmas -std=c++0x -fPIC")
-  set(CMAKE_CXX_FLAGS ${CMAKE_C_FLAGS}) 
+  set(CMAKE_CXX_FLAGS ${CMAKE_C_FLAGS})
 endif(MSVC)
 
 FILE(GLOB SOURCE "src/*.cc")
@@ -75,16 +76,16 @@ list(APPEND SOURCE "src/io/input_split_base.cc")
 list(APPEND SOURCE "src/io/local_filesys.cc")
 
 if(USE_HDFS)
-	list(APPEND SOURCE "src/io/hdfs_filesys.cc")
+  list(APPEND SOURCE "src/io/hdfs_filesys.cc")
 endif()
 if(USE_S3)
-	list(APPEND SOURCE "src/io/s3_filesys.cc")
+  list(APPEND SOURCE "src/io/s3_filesys.cc")
 endif()
 if(USE_AZURE)
-	list(APPEND SOURCE "src/io/azure_filesys.cc")
+  list(APPEND SOURCE "src/io/azure_filesys.cc")
 endif()
 
-add_library(dmlccore ${SOURCE}) 
+add_library(dmlccore ${SOURCE})
 target_link_libraries(dmlccore ${dmlccore_LINKER_LIBS})
 
 # ---[ Linter target

--- a/cmake/Modules/FindHDFS.cmake
+++ b/cmake/Modules/FindHDFS.cmake
@@ -1,0 +1,72 @@
+# DerivedFrom: https://github.com/cloudera/Impala/blob/cdh5-trunk/cmake_modules/FindHDFS.cmake
+# - Find HDFS (hdfs.h and libhdfs.so)
+# This module defines
+#  Hadoop_VERSION, version string of ant if found
+#  HDFS_INCLUDE_DIR, directory containing hdfs.h
+#  HDFS_LIBRARIES, location of libhdfs.so
+#  HDFS_FOUND, whether HDFS is found.
+#  hdfs_static, imported static hdfs library.
+
+exec_program(hadoop ARGS version OUTPUT_VARIABLE Hadoop_VERSION
+             RETURN_VALUE Hadoop_RETURN)
+
+# currently only looking in HADOOP_HOME
+find_path(HDFS_INCLUDE_DIR hdfs.h PATHS
+  $ENV{HADOOP_HOME}/include/
+  # make sure we don't accidentally pick up a different version
+  NO_DEFAULT_PATH
+)
+
+if ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "8")
+  set(arch_hint "x64")
+elseif ("$ENV{LIB}" MATCHES "(amd64|ia64)")
+  set(arch_hint "x64")
+else ()
+  set(arch_hint "x86")
+endif()
+
+message(STATUS "Architecture: ${arch_hint}")
+
+if ("${arch_hint}" STREQUAL "x64")
+  set(HDFS_LIB_PATHS $ENV{HADOOP_HOME}/lib/native)
+else ()
+  set(HDFS_LIB_PATHS $ENV{HADOOP_HOME}/lib/native)
+endif ()
+
+message(STATUS "HDFS_LIB_PATHS: ${HDFS_LIB_PATHS}")
+
+find_library(HDFS_LIB NAMES hdfs PATHS
+  ${HDFS_LIB_PATHS}
+  # make sure we don't accidentally pick up a different version
+  NO_DEFAULT_PATH
+)
+
+if (HDFS_LIB)
+  set(HDFS_FOUND TRUE)
+  set(HDFS_LIBRARIES ${HDFS_LIB})
+  set(HDFS_STATIC_LIB ${HDFS_LIB_PATHS}/libhdfs.a)
+
+  add_library(hdfs_static STATIC IMPORTED)
+  set_target_properties(hdfs_static PROPERTIES IMPORTED_LOCATION ${HDFS_STATIC_LIB})
+
+else ()
+  set(HDFS_FOUND FALSE)
+endif ()
+
+if (HDFS_FOUND)
+  if (NOT HDFS_FIND_QUIETLY)
+    message(STATUS "${Hadoop_VERSION}")
+    message(STATUS "HDFS_INCLUDE_DIR: ${HDFS_INCLUDE_DIR}")
+    message(STATUS "HDFS_LIBRARIES: ${HDFS_LIBRARIES}")
+    message(STATUS "hdfs_static: ${HDFS_STATIC_LIB}")
+  endif ()
+else ()
+  message(FATAL_ERROR "HDFS includes and libraries NOT found."
+    "(${HDFS_INCLUDE_DIR}, ${HDFS_LIB})")
+endif ()
+
+mark_as_advanced(
+  HDFS_LIBRARIES
+  HDFS_INCLUDE_DIR
+  hdfs_static
+)


### PR DESCRIPTION
When building the library in cmake with HDFS, it was looking for HDF**5** library. In this pull request, I changed it to the correct HDFS library (by including a FindHDFS module).

Note that the encoding of CMakeLists.txt has also been changed from UTF-8 to ascii. On my ubuntu 14.04,  cmake failed to parse UTF-8 scripts.