### PR TITLE
fix tracker/dmlc_local.py

### DIFF
--- a/tracker/dmlc_local.py
+++ b/tracker/dmlc_local.py
@@ -89,7 +89,7 @@ def mthread_submit(nworker, nserver, envs):
             role = 'worker'
         else:
             role = 'server'
-        procs[i] = Thread(target = exec_cmd, args = (args.command, role, i, envs))
+        procs[i] = Thread(target = exec_cmd, args = (args.command + unknown, role, i, envs))
         procs[i].setDaemon(True)
         procs[i].start()
 


### PR DESCRIPTION
When submitting ps application locally, application argument is lost for server and worker. 
```
F0106 18:51:25.063443 80525 linear.cc:7] Check failed: argc >= 2 (1 vs. 2) 
usage: /home/z/dev-pla/wormhole/bin/linear.dmlc conf_file
*** Check failure stack trace: ***
F0106 18:51:25.063741 80528 linear.cc:7] Check failed: argc >= 2 (1 vs. 2) 
usage: /home/z/dev-pla/wormhole/bin/linear.dmlc conf_file
*** Check failure stack trace: ***
    @     0x7f072d6a8daa  (unknown)
    @     0x7f072d6a8ce4  (unknown)
    @     0x7f6f7ca01daa  (unknown)
    @     0x7f072d6a86e6  (unknown)
    @     0x7f6f7ca01ce4  (unknown)
    @     0x7f072d6ab687  (unknown)
    @     0x7f6f7ca016e6  (unknown)
    @           0x411c1d  ps::App::Create()
    @           0x46873d  ps::Manager::Init()
    @     0x7f6f7ca04687  (unknown)
    @           0x46b6e3  ps::Postoffice::Run()
    @           0x411c1d  ps::App::Create()
    @           0x409851  main
    @           0x46873d  ps::Manager::Init()
    @     0x7f072c6a7ec5  (unknown)
    @           0x46b6e3  ps::Postoffice::Run()
    @           0x409851  main
    @     0x7f6f7ba00ec5  (unknown)
    @           0x40ac1f  (unknown)
    @              (nil)  (unknown)
    @           0x40ac1f  (unknown)
    @              (nil)  (unknown)
bash: line 9: 80528 Aborted                 (core dumped) /home/z/dev-pla/wormhole/bin/linear.dmlc
bash: line 9: 80525 Aborted                 (core dumped) /home/z/dev-pla/wormhole/bin/linear.dmlc
```
That is caused by the incomplete argument of `mthread_submit` in tracker/dmlc_local.py.
