### PR TITLE
Fix the segmentation fault with ostream caused by invalid pointer access.

### DIFF
--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -266,7 +266,7 @@ class ostream : public std::basic_ostream<char> {
     }
 
     // release the internal Stream object.
-    virtual ~OutBuf(){
+    virtual ~OutBuf() {
       delete stream_;
       stream_ = NULL;
     }
@@ -275,6 +275,7 @@ class ostream : public std::basic_ostream<char> {
     inline void set_stream(Stream *stream);
 
     inline size_t bytes_out() const { return bytes_out_; }
+
    private:
     /*! \brief internal stream by StreamBuf */
     Stream *stream_;
@@ -346,7 +347,7 @@ class istream : public std::basic_istream<char> {
     }
 
     // release the internal Stream object.
-    virtual ~InBuf(){
+    virtual ~InBuf() {
       delete stream_;
       stream_ = NULL;
     }
@@ -356,6 +357,7 @@ class istream : public std::basic_istream<char> {
     inline size_t bytes_read(void) const {
       return bytes_read_;
     }
+
    private:
     /*! \brief internal stream by StreamBuf */
     Stream *stream_;
@@ -386,7 +388,7 @@ inline bool Stream::Read(T *out_data) {
 
 // implementations for ostream
 inline void ostream::OutBuf::set_stream(Stream *stream) {
-  if (this->stream_ != NULL){
+  if (this->stream_ != NULL) {
     this->pubsync();
     delete stream_;
     this->stream_ = NULL;
@@ -395,7 +397,7 @@ inline void ostream::OutBuf::set_stream(Stream *stream) {
   this->setp(&buffer_[0], &buffer_[0] + buffer_.size() - 1);
 }
 inline int ostream::OutBuf::sync(void) {
-  if (stream_ == NULL)return -1;
+  if (stream_ == NULL) return -1;
   std::ptrdiff_t n = pptr() - pbase();
   stream_->Write(pbase(), n);
   this->pbump(-static_cast<int>(n));
@@ -418,7 +420,7 @@ inline int ostream::OutBuf::overflow(int c) {
 
 // implementations for istream
 inline void istream::InBuf::set_stream(Stream *stream) {
-  if (this->stream_ != NULL){
+  if (this->stream_ != NULL) {
     delete this->stream_;
     this->stream_ = NULL;
   }

--- a/test/iostream_test.cc
+++ b/test/iostream_test.cc
@@ -7,19 +7,15 @@ int main(int argc, char *argv[]) {
     return 0;
   }
   {// output
-    dmlc::Stream *fs = dmlc::Stream::Create(argv[1], "w");
-    dmlc::ostream os(fs);
+    dmlc::ostream os(argv[1]);
     os << "hello-world " << 1e-10<< std::endl;
-    delete fs;
   }
   {// input
     std::string name;
     double data;
-    dmlc::Stream *fs = dmlc::Stream::Create(argv[1], "r");
-    dmlc::istream is(fs);
+    dmlc::istream is(argv[1]);
     is >> name >> data;
     std::cout << name << " " << data << std::endl;
-    delete fs;
   }
   return 0;
 }


### PR DESCRIPTION
This pull request fixes a segmentation fault in current `ostream`.

In the current code base, `iostream` is used as follows:

    Stream *fs = Stream::Create("hdfs:///test.txt", "w");
    dmlc::ostream os(fs);       // <-- os does not own the fs pointer.
    os << "hello world" << std::endl;
    delete fs;                  // <-- the fs pointer gets deleted.
    // SIGSEGV when os is destructed.

When destructing the `os` object, it tries to sync the buffer which accesses the memory that has been deleted. When I ran `test/test_iostream` with HDFS, it caused a segmentation fault!

To fix this, in this pull request, I changed the interface and make `ostream` and `istream` instances own the underlying Streams. Specifically, they create the stream in the constructor and release the stream (and therefore close the file) at the destruction. The usage becomes:

    dmlc::ostream os("hdfs:///test.txt");
    os << "hello world" << std::end;
    // file will be closed when os is destructed.

The inline docxygen docs have been updated accordingly.

Discussion: later it may be better to add a `close()` function to allow closing the file explicitly. And it seems to me that it would make more sense if `In/OutBuf`inherits from `filebuf` instead of `streambuf`. However, this will involve much bigger changes. So, to avoid messing up the base with a huge PR, I am submitting this PR at the current point. Please let me know what you think.