### PR TITLE
[YARN] Specify node's `host` in container env.

### DIFF
--- a/yarn/src/main/java/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
+++ b/yarn/src/main/java/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
@@ -396,6 +396,8 @@ public class ApplicationMaster {
                 env.put(e.getKey(), e.getValue());
             }
         }
+        String nodeHost = container.getNodeId().getHost();
+        env.put("DMLC_NODE_HOST", nodeHost);
         env.put("DMLC_TASK_ID", String.valueOf(task.taskId));
         env.put("DMLC_ROLE", task.taskRole);
         env.put("DMLC_NUM_ATTEMPT", String.valueOf(task.attemptCounter));


### PR DESCRIPTION
The current implementation gets ip/host via querying network adaptor info. This will raise issues when the ip/host got is not accessible from outside the container. To fix this, we can use the YARN node host of the container, which is guaranteed to be accessible from outside the container, i.e. other containers and the YARN client node.

This commit just set the node host to the container's env. To use the node host, we can get the env from the application program, such as those based on ps-lite, executed on YARN.