### PR TITLE
mingw doesn't have fopen64

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -110,6 +110,9 @@
 #if !defined(__GNUC__)
 #define fopen64 std::fopen
 #endif
+#if (defined __MINGW32__) || (defined __MINGW64__)
+#define fopen64 std::fopen
+#endif
 #ifdef _MSC_VER
 #if _MSC_VER < 1900
 // NOTE: sprintf_s is not equivalent to snprintf,


### PR DESCRIPTION
Some MinGW distribution doesn't define `fopen64` and even `fopen64` is defined, it is just redirect to `fopen`. 

https://sourceforge.net/p/mingw-w64/code/HEAD/tree/trunk/mingw-w64-crt/stdio/fopen64.c