### PR TITLE
Fix the openmp flag bug

### DIFF
--- a/make/dmlc.mk
+++ b/make/dmlc.mk
@@ -10,7 +10,7 @@ ifndef LIBJVM
 	LIBJVM=$(JAVA_HOME)/jre/lib/amd64/server
 endif
 
-ifndef NO_OPENMP
+ifneq ($(USE_OPENMP), 0)
 	DMLC_CFLAGS += -fopenmp
 	DMLC_LDFLAGS += -fopenmp
 endif


### PR DESCRIPTION
Change NO_OPENMP flag in dmlc.mk to USE_OPENMP
Solve the issues from https://github.com/dmlc/mxnet/issues/1579, https://github.com/dmlc/mxnet/issues/2078