### PR TITLE
Don't redefine fopen64 on a 64-bit platform

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -110,7 +110,7 @@
 #if !defined(__GNUC__)
 #define fopen64 std::fopen
 #endif
-#if (defined __MINGW32__) || (defined __MINGW64__)
+#if (defined __MINGW32__) && !(defined __MINGW64__)
 #define fopen64 std::fopen
 #endif
 #ifdef _MSC_VER


### PR DESCRIPTION
On mingw64 (installed via msys2), gcc defines look like the following:
$ gcc -dM -E - < /dev/null |grep MINGW
#define __MINGW32__ 1
#define __MINGW64__ 1

However e0b197c49 redefines fopen on 32bit and 64bit platforms.

diff --git a/include/dmlc/base.h b/include/dmlc/base.h
index 01413f1..9d6acd5 100644
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -110,6 +110,9 @@
 #if !defined(__GNUC__)
 #define fopen64 std::fopen
 #endif
+#if (defined __MINGW32__) || (defined __MINGW64__)
+#define fopen64 std::fopen
+#endif
 #ifdef _MSC_VER
 #if _MSC_VER < 1900
 // NOTE: sprintf_s is not equivalent to snprintf,
On mingw64 (installed via msys2), gcc defines look like the following:
$ gcc -dM -E - < /dev/null |grep MINGW
#define __MINGW32__ 1
#define __MINGW64__ 1

However e0b197c49 redefines fopen on 32bit and 64bit platforms.

diff --git a/include/dmlc/base.h b/include/dmlc/base.h
index 01413f1..9d6acd5 100644
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -110,6 +110,9 @@
 #if !defined(__GNUC__)
 #define fopen64 std::fopen
 #endif
+#if (defined __MINGW32__) || (defined __MINGW64__)
+#define fopen64 std::fopen
+#endif
 #ifdef _MSC_VER
 #if _MSC_VER < 1900
 // NOTE: sprintf_s is not equivalent to snprintf,

See also https://github.com/dmlc/xgboost/issues/1267