### PR TITLE
In line 149, change {98, 48} to [98, 48].

### DIFF
--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -146,7 +146,7 @@ class RabitTracker(object):
                 self.port = port
                 break
             except socket.error as e:
-                if e.errno in {98, 48}:
+                if e.errno in [98, 48]:
                     continue
                 else:
                     raise


### PR DESCRIPTION
Python 2.6 has no support to this set literal  {}, and I have changed {98, 48} to [98, 48] @Earthson