### PR TITLE
FreeBSD (as of 10.3) does not include fopen64. Add extra checks and replace fopen64 with fopen.

### DIFF
--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -17,6 +17,11 @@ extern "C" {
 
 #include "./local_filesys.h"
 
+#if defined(__FreeBSD__)
+#define fopen64 std::fopen
+#endif
+
+
 namespace dmlc {
 namespace io {
 /*! \brief implementation of file i/o stream */

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -13,6 +13,10 @@
 #include <string>
 #include <algorithm>
 
+#if defined(__FreeBSD__)
+#define fopen64 std::fopen
+#endif
+
 namespace dmlc {
 namespace io {
 /*!


### PR DESCRIPTION
Inspired by dmlc/rabit, replace fopen64 with standard fopen.