### PR TITLE
chunked input split for global shuffling

### DIFF
--- a/include/dmlc/input_split_shuffle.h
+++ b/include/dmlc/input_split_shuffle.h
@@ -1,0 +1,135 @@
+/*!
+ *  Copyright (c) 2016 by Contributors
+ * \file input_split_shuffle.h
+ * \brief base class to construct input split with global shuffling
+ * \author Yifeng Geng
+ */
+#ifndef DMLC_INPUT_SPLIT_SHUFFLE_H_
+#define DMLC_INPUT_SPLIT_SHUFFLE_H_
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+namespace dmlc {
+/*! \brief class to construct input split with global shuffling */
+class InputSplitShuffle : public InputSplit {
+ public:
+  // destructor
+  virtual ~InputSplitShuffle(void) { source_.reset(); }
+  // implement BeforeFirst
+  virtual void BeforeFirst(void) {
+    if (num_shuffle_parts_ > 1) {
+      std::shuffle(shuffle_indexes_.begin(), shuffle_indexes_.end(), trnd_);
+      int idx = shuffle_indexes_[0] + part_index_ * num_shuffle_parts_;
+      source_->ResetPartition(idx, num_parts_ * num_shuffle_parts_);
+      cur_shuffle_idx_ = 0;
+    } else {
+      source_->BeforeFirst();
+    }
+  }
+  virtual void HintChunkSize(size_t chunk_size) {
+    source_->HintChunkSize(chunk_size);
+  }
+  virtual size_t GetTotalSize(void) {
+    return source_->GetTotalSize();
+  }
+  // implement next record
+  virtual bool NextRecord(Blob *out_rec) {
+    if (num_shuffle_parts_ > 1) {
+      if (!source_->NextRecord(out_rec)) {
+        if (cur_shuffle_idx_ == num_shuffle_parts_ - 1) {
+          return false;
+        }
+        ++cur_shuffle_idx_;
+        int idx =
+            shuffle_indexes_[cur_shuffle_idx_] + part_index_ * num_shuffle_parts_;
+        source_->ResetPartition(idx, num_parts_ * num_shuffle_parts_);
+        return NextRecord(out_rec);
+      } else {
+        return true;
+      }
+    } else {
+      return source_->NextRecord(out_rec);
+    }
+  }
+  // implement next chunk
+  virtual bool NextChunk(Blob* out_chunk) {
+    if (num_shuffle_parts_ > 1) {
+      if (!source_->NextChunk(out_chunk)) {
+        if (cur_shuffle_idx_ == num_shuffle_parts_ - 1) {
+          return false;
+        }
+        ++cur_shuffle_idx_;
+        int idx =
+            shuffle_indexes_[cur_shuffle_idx_] + part_index_ * num_shuffle_parts_;
+        source_->ResetPartition(idx, num_parts_ * num_shuffle_parts_);
+        return NextChunk(out_chunk);
+      } else {
+        return true;
+      }
+    } else {
+      return source_->NextChunk(out_chunk);
+    }
+  }
+  // implement ResetPartition.
+  virtual void ResetPartition(unsigned rank, unsigned nsplit) {
+    CHECK(nsplit == num_parts_) << "num_parts is not consistent!";
+    int idx = shuffle_indexes_[0] + rank * num_shuffle_parts_;
+    source_->ResetPartition(idx, nsplit * num_shuffle_parts_);
+    cur_shuffle_idx_ = 0;
+  }
+
+  InputSplitShuffle(const char* uri,
+                    unsigned part_index,
+                    unsigned num_parts,
+                    const char* type,
+                    unsigned num_shuffle_parts,
+                    int shuffle_seed)
+      : part_index_(part_index),
+        num_parts_(num_parts),
+        num_shuffle_parts_(num_shuffle_parts),
+        cur_shuffle_idx_(0) {
+    for (unsigned i = 0; i < num_shuffle_parts_; i++) {
+      shuffle_indexes_.push_back(i);
+    }
+    trnd_.seed(kRandMagic_ +  num_parts_ + num_shuffle_parts_ + shuffle_seed);
+    std::shuffle(shuffle_indexes_.begin(), shuffle_indexes_.end(), trnd_);
+    int idx = shuffle_indexes_[cur_shuffle_idx_] + part_index_ * num_shuffle_parts_;
+    source_.reset(
+        InputSplit::Create(uri, idx , num_parts_ * num_shuffle_parts_, type));
+  }
+
+  static InputSplit* Create(const char* uri,
+                            unsigned part_index,
+                            unsigned num_parts,
+                            const char* type,
+                            unsigned num_shuffle_parts,
+                            int shuffle_seed) {
+    CHECK(num_shuffle_parts > 0) << "number of shuffle parts should be greater than zero!";
+    return new InputSplitShuffle(
+        uri, part_index, num_parts, type, num_shuffle_parts, shuffle_seed);
+  }
+
+ private:
+  // magic nyumber for seed
+  static const int kRandMagic_ = 666;
+  /*! \brief random engine */
+  std::mt19937 trnd_;
+  /*! \brief inner inputsplit */
+  std::unique_ptr<InputSplit> source_;
+  /*! \brief part index */
+  unsigned part_index_;
+  /*! \brief number of parts */
+  unsigned num_parts_;
+  /*! \brief the number of block for shuffling*/
+  unsigned num_shuffle_parts_;
+  /*! \brief current shuffle block index */
+  unsigned cur_shuffle_idx_;
+  /*! \brief shuffled indexes */
+  std::vector<int> shuffle_indexes_;
+};
+}  // namespace dmlc
+#endif  // DMLC_INPUT_SPLIT_SHUFFLE_H_

--- a/include/dmlc/input_split_shuffle.h
+++ b/include/dmlc/input_split_shuffle.h
@@ -93,8 +93,8 @@ class InputSplitShuffle : public InputSplit {
    *         input split will split on '\\n' or '\\r'
    *     - "recordio":
    *         binary recordio file, see recordio.h
-   * \param number of shuffle chunks for each split
-   * \param the shuffle seed for chunk shuffling
+   * \param num_shuffle_parts number of shuffle chunks for each split
+   * \param shuffle_seed shuffle seed for chunk shuffling
    */
   InputSplitShuffle(const char* uri,
                     unsigned part_index,
@@ -129,8 +129,8 @@ class InputSplitShuffle : public InputSplit {
    *         input split will split on '\\n' or '\\r'
    *     - "recordio":
    *         binary recordio file, see recordio.h
-   * \param number of shuffle chunks for each split
-   * \param the shuffle seed for chunk shuffling
+   * \param num_shuffle_parts number of shuffle chunks for each split
+   * \param shuffle_seed shuffle seed for chunk shuffling
    * \return a new input split
    * \sa InputSplit::Type
    */

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -150,6 +150,8 @@ class InputSplit {
    * \param chunk_size the chunk size
    */
   virtual void HintChunkSize(size_t chunk_size) {}
+  /*! \brief get the total size of the InputSplit */
+  virtual size_t GetTotalSize(void) = 0;
   /*! \brief reset the position of InputSplit to beginning */
   virtual void BeforeFirst(void) = 0;
   /*!

--- a/src/io/cached_input_split.h
+++ b/src/io/cached_input_split.h
@@ -90,6 +90,9 @@ class CachedInputSplit : public InputSplit {
   virtual void HintChunkSize(size_t chunk_size) {
     buffer_size_ = std::max(chunk_size / sizeof(size_t), buffer_size_);
   }
+  virtual size_t GetTotalSize(void) {
+    return base_->GetTotalSize();
+  }
   // implement next record
   virtual bool NextRecord(Blob *out_rec) {
     auto *iter = iter_preproc_ != NULL ? iter_preproc_ : &iter_cached_;

--- a/src/io/input_split_base.h
+++ b/src/io/input_split_base.h
@@ -43,6 +43,9 @@ class InputSplitBase : public InputSplit {
   virtual void HintChunkSize(size_t chunk_size) {
     buffer_size_ = std::max(chunk_size / sizeof(size_t), buffer_size_);
   }
+  virtual size_t GetTotalSize(void){
+    return file_offset_.back();
+  }
   // implement next record
   virtual bool NextRecord(Blob *out_rec) {
     while (!ExtractNextRecord(out_rec, &tmp_chunk_)) {

--- a/src/io/input_split_base.h
+++ b/src/io/input_split_base.h
@@ -43,7 +43,7 @@ class InputSplitBase : public InputSplit {
   virtual void HintChunkSize(size_t chunk_size) {
     buffer_size_ = std::max(chunk_size / sizeof(size_t), buffer_size_);
   }
-  virtual size_t GetTotalSize(void){
+  virtual size_t GetTotalSize(void) {
     return file_offset_.back();
   }
   // implement next record

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -9,10 +9,10 @@
 
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
+#include <sys/stat.h>
 #include <cstdio>
 #include <string>
 #include <algorithm>
-#include<sys/stat.h>
 
 #if defined(__FreeBSD__)
 #define fopen64 std::fopen

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <string>
 #include <algorithm>
+#include<sys/stat.h>
 
 #if defined(__FreeBSD__)
 #define fopen64 std::fopen
@@ -47,6 +48,11 @@ class SingleFileSplit : public InputSplit {
   }
   virtual void HintChunkSize(size_t chunk_size) {
     buffer_size_ = std::max(chunk_size, buffer_size_);
+  }
+  virtual size_t GetTotalSize(void) {
+    struct stat buf;
+    fstat(fileno(fp_), &buf);
+    return buf.st_size;
   }
   virtual size_t Read(void *ptr, size_t size) {
     return std::fread(ptr, 1, size, fp_);


### PR DESCRIPTION
With this PR and small changes in data iterators, we can achieve global shuffling. Current implementation does shuffling within an chunk, but a record can not be randomly placed across chunks. The idea for global shuffling is to create more chunks and shuffle chunks first, then shuffle records within a chunk. So the records are shuffled globally.