### PR TITLE
Disable stack-tracing for MinGW

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,7 +41,7 @@
  * \brief Wheter to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__))
+#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__))
 #define DMLC_LOG_STACK_TRACE 1
 #endif
 

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -869,7 +869,7 @@ class FieldEntry<optional<int> >
       if (!value) {
         os << "None";
       } else {
-        CHECK_NE(enum_back_map_.count(value.value()), 0)
+        CHECK_NE(enum_back_map_.count(value.value()), 0UL)
             << "Value not found in enum declared";
         os << enum_back_map_.at(value.value());
       }

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -641,18 +641,18 @@ class FieldEntryNumeric
     if (has_begin_ && has_end_) {
       if (v < begin_ || v > end_) {
         std::ostringstream os;
-        os << "value " << v << "for Parameter " << this->key_
+        os << "value " << v << " for Parameter " << this->key_
            << " exceed bound [" << begin_ << ',' << end_ <<']';
         throw dmlc::ParamError(os.str());
       }
     } else if (has_begin_ && v < begin_) {
         std::ostringstream os;
-        os << "value " << v << "for Parameter " << this->key_
+        os << "value " << v << " for Parameter " << this->key_
            << " should be greater equal to " << begin_;
         throw dmlc::ParamError(os.str());
     } else if (has_end_ && v > end_) {
         std::ostringstream os;
-        os << "value " << v << "for Parameter " << this->key_
+        os << "value " << v << " for Parameter " << this->key_
            << " should be smaller equal to " << end_;
         throw dmlc::ParamError(os.str());
     }


### PR DESCRIPTION
MinGW doesn't seem to have execinfo.h