### PR TITLE
add DMLC_SERVER_ID and DMLC_WORKER_ID to enable Map-Reduce on Workers

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -70,6 +70,10 @@ def submit(args):
         # launch jobs
         for i in range(nworker + nserver):
             pass_envs['DMLC_ROLE'] = 'server' if i < nserver else 'worker'
+            if i < nserver:
+                pass_envs['DMLC_SERVER_ID'] = i
+            else:
+                pass_envs['DMLC_WORKER_ID'] = i - nserver
             (node, port) = hosts[i % len(hosts)]
             prog = get_env(pass_envs) + ' cd ' + working_dir + '; ' + (' '.join(args.command))
             prog = 'ssh -o StrictHostKeyChecking=no ' + node + ' -p ' + port + ' \'' + prog + '\''


### PR DESCRIPTION
Add environment variables `DMLC_SERVER_ID` and `DMLC_WORKER_ID` before launching code via `ssh` in order to realise Map-Reduce operations on Workers.