### PR TITLE
add cpu thread control for CPU/PHI training

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -23,7 +23,7 @@ def sync_dir(local_dir, slave_node, slave_dir):
 def get_env(pass_envs):
     envs = []
     # get system envs
-    keys = ['LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']
+    keys = ['OMP_NUM_THREADS', 'KMP_AFFINITY', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']
     for k in keys:
         v = os.getenv(k)
         if v is not None:


### PR DESCRIPTION
Hi @piiswrong  this params are required when running training on XEON/PHI when utilizing MKL Ops. 