### PR TITLE
Rename library file from libdmlccore.a to libdmlc.a in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,16 +118,21 @@ if(USE_AZURE)
   list(APPEND SOURCE "src/io/azure_filesys.cc")
 endif()
 
-add_library(dmlccore ${SOURCE})
-target_link_libraries(dmlccore ${dmlccore_LINKER_LIBS})
+add_library(dmlc ${SOURCE})
+target_link_libraries(dmlc ${dmlccore_LINKER_LIBS})
 
 # ---[ Install Includes
 if(INSTALL_INCLUDE_DIR)
-  add_custom_command(TARGET dmlccore POST_BUILD
+  add_custom_command(TARGET dmlc POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${PROJECT_SOURCE_DIR}/include ${INSTALL_INCLUDE_DIR}/
     )
 endif()
+
+# ---[ Install the archive static lib and header files
+install(TARGETS dmlc ARCHIVE DESTINATION lib) 
+install(DIRECTORY include DESTINATION .)
+install(DIRECTORY doc DESTINATION .)
 
 # ---[ Linter target
 if(MSVC)


### PR DESCRIPTION
Static library name are inconsistent between ones generated by `Makefile` and `CMakeLists.txt`. After confriming in projects depending on `dmlc-core` like `mxnet`, I think `libdmlc.a` should be the desired one.

This commit:
1. Renames `libdmlccore.a` to `libdmcl.a` in `CMakeLists.txt`.
2. Add the `install` target in `CMakeLists.txt`.
3. Add cmake intermediate files into `.gitignore`.

This commit doesn't change the building process that uses `Makefile`. So `dmlc-core` and `mxnet` should not be affected. However, some fancy features on CMake over Makefile (better adapability between compilers, architectures, etc) pursuades me that boostrap should be done via CMake, let alone execellent CMake build files deveveloped by dmlc community is already here. Currently `Makefile` is duplicated with `CMakeLists.txt` in function, and I hope the build system can be migrated to CMake some day.

I am adding `mxnet` package to Spack's repo. Originated from the sueprcomputer center in Lawrence Livermore National Laboratory, [Spack](https://github.com/LLNL/spack) enables co-exists of packages of various versions and various feature flags, plus tools to manage dependency between libraries. The work, `mxnet` package in Spack and Spack itself,  are still in development. I appreciate feedbacks from the dmlc community.

https://github.com/LLNL/spack/pull/3579