### PR TITLE
[master] Ignore warning "-Wplacement-new".

### DIFF
--- a/include/dmlc/any.h
+++ b/include/dmlc/any.h
@@ -182,7 +182,10 @@ inline any::any(T&& other) {
                   "Any can only hold value that is copy constructable");
     type_ = TypeInfo<DT>::get_type();
     if (data_on_stack<DT>::value) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wplacement-new"
       new (&(data_.stack)) DT(std::forward<T>(other));
+#pragma GCC diagnostic pop
     } else {
       data_.pheap = new DT(std::forward<T>(other));
     }

--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -87,12 +87,15 @@ class LogCheckError {
     dmlc::LogMessageFatal(__FILE__, __LINE__).stream()                \
       << "Check failed: " << #x " " #op " " #y << *(_check_err.str)
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
 DEFINE_CHECK_FUNC(_LT, <)
 DEFINE_CHECK_FUNC(_GT, >)
 DEFINE_CHECK_FUNC(_LE, <=)
 DEFINE_CHECK_FUNC(_GE, >=)
 DEFINE_CHECK_FUNC(_EQ, ==)
 DEFINE_CHECK_FUNC(_NE, !=)
+#pragma GCC diagnostic pop
 
 // Always-on checking
 #define CHECK(x)                                           \


### PR DESCRIPTION
When compiling MXNet, this use of `any` generates a lot of warnings. This `pragma` temporarily disables this warning for GCC.