### PR TITLE
[master] -Wplacement-new is introduced in GCC 6.

### DIFF
--- a/include/dmlc/any.h
+++ b/include/dmlc/any.h
@@ -183,7 +183,9 @@ inline any::any(T&& other) {
     type_ = TypeInfo<DT>::get_type();
     if (data_on_stack<DT>::value) {
 #pragma GCC diagnostic push
+#if 6 <= __GNUC__
 #pragma GCC diagnostic ignored "-Wplacement-new"
+#endif
       new (&(data_.stack)) DT(std::forward<T>(other));
 #pragma GCC diagnostic pop
     } else {


### PR DESCRIPTION
@sxjscience Could you please check whether this fixes the compilation error?

I was not aware that "-Wplacement-new" does not exist in previous versions.