### PR TITLE
revert export of DMLC_SERVER_ID and DMLC_WORKER_ID

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -70,10 +70,6 @@ def submit(args):
         # launch jobs
         for i in range(nworker + nserver):
             pass_envs['DMLC_ROLE'] = 'server' if i < nserver else 'worker'
-            if i < nserver:
-                pass_envs['DMLC_SERVER_ID'] = i
-            else:
-                pass_envs['DMLC_WORKER_ID'] = i - nserver
             (node, port) = hosts[i % len(hosts)]
             prog = get_env(pass_envs) + ' cd ' + working_dir + '; ' + (' '.join(args.command))
             prog = 'ssh -o StrictHostKeyChecking=no ' + node + ' -p ' + port + ' \'' + prog + '\''


### PR DESCRIPTION
`mxnet.kvstore.KVStore.rank` and `money.kvstore.KVStore.num_workers` should suffice for the purpose of identifying the worker node. I'm reverting the previous merge #220 .