### PR TITLE
Use GNUInstallDirs for standard conforming install target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,13 @@ if(INSTALL_INCLUDE_DIR)
 endif()
 
 # ---[ Install the archive static lib and header files
-install(TARGETS dmlc ARCHIVE DESTINATION lib LIBRARY DESTINATION lib) 
-install(DIRECTORY include DESTINATION .)
-install(DIRECTORY doc DESTINATION .)
+include(GNUInstallDirs)
+install(TARGETS dmlc
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY doc/ DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/${PROJECT_NAME})
 
 # ---[ Linter target
 if(MSVC)


### PR DESCRIPTION
This PR replaces the custom commands for install targets with the CMake `install()` command. Additionally, it uses `GNUInstallDirs.cmake` [1] to install to different types of files to the right location.

Additionally, `GNUInstallDirs` allows the user to override the install location of different types of files with well-known variable names (`-DCMAKE_INSTALL_LIBDIR`, `-DCMAKE_INSTALL_INCLUDEDIR`, `...`).

This makes it much easier to package the software for a package manager.

[1] https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html