### PR TITLE
Update Row class so that it's easier to construct tensors for label and weights in MXNet

### DIFF
--- a/include/dmlc/data.h
+++ b/include/dmlc/data.h
@@ -70,9 +70,9 @@ template<typename IndexType>
 class Row {
  public:
   /*! \brief label of the instance */
-  real_t label;
+  const real_t *label;
   /*! \brief weight of the instance */
-  real_t weight;
+  const real_t *weight;
   /*! \brief length of the sparse vector */
   size_t length;
   /*!
@@ -326,11 +326,11 @@ inline Row<IndexType>
 RowBlock<IndexType>::operator[](size_t rowid) const {
   CHECK(rowid < size);
   Row<IndexType> inst;
-  inst.label = label[rowid];
+  inst.label = label + rowid;
   if (weight != NULL) {
-    inst.weight = weight[rowid];
+    inst.weight = weight + rowid;
   } else {
-    inst.weight = 1.0f;
+    inst.weight = NULL;
   }
   inst.length = offset[rowid + 1] - offset[rowid];
   if (field != NULL) {

--- a/include/dmlc/data.h
+++ b/include/dmlc/data.h
@@ -111,6 +111,19 @@ class Row {
     return value == NULL ? 1.0f : value[i];
   }
   /*!
+   * \return the label of the instance
+   */
+  inline real_t get_label() const {
+    return *label;
+  }
+  /*!
+   * \return the weight of the instance, this function is always
+   *  safe even when weight == NULL
+   */
+  inline real_t get_weight() const {
+    return weight == NULL ? 1.0f : *weight;
+  }
+  /*!
    * \brief helper function to compute dot product of current
    * \param weight the dense array of weight we want to product
    * \param size the size of the weight vector

--- a/src/data/row_block.h
+++ b/src/data/row_block.h
@@ -85,8 +85,8 @@ struct RowBlockContainer {
    */
   template<typename I>
   inline void Push(Row<I> row) {
-    label.push_back(row.label);
-    weight.push_back(row.weight);
+    label.push_back(row.get_label());
+    weight.push_back(row.get_weight());
     if (row.field != NULL) {
       for (size_t i = 0; i < row.length; ++i) {
         CHECK_LE(row.field[i], std::numeric_limits<IndexType>::max())


### PR DESCRIPTION
@tqchen this change is mainly for https://github.com/eric-haibin-lin/mxnet/pull/55 so that I don't have to allocate extra memory to hold the label in libsvm iter. Will changing interface introduce problems for other projects depending on dmlc-core?