### PR TITLE
Disable DMLC_LOG_STACK_TRACE on MinGW64

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,7 +41,7 @@
  * \brief Wheter to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__))
+#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__) && !(defined __MINGW64__))
 #define DMLC_LOG_STACK_TRACE 1
 #endif
 


### PR DESCRIPTION
The `<execinfo.h>` header enabled by this flag is not available on MinGW64 as well.