### PR TITLE
Added missing include to hdfs_filesys.cc

### DIFF
--- a/src/io/hdfs_filesys.cc
+++ b/src/io/hdfs_filesys.cc
@@ -1,6 +1,9 @@
 // Copyright by Contributors
-#include <dmlc/logging.h>
+#include <algorithm>
 #include <limits>
+
+#include <dmlc/logging.h>
+
 #include "./hdfs_filesys.h"
 
 namespace dmlc {


### PR DESCRIPTION
`std::min` requires `algorithm` header as per the standard. It seems to
work without it on Linux/OS X but breaks on Windows.