### PR TITLE
DMLC_GLOG_DEFINED to disable definition of LOG

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -71,6 +71,8 @@ class LogCheckError {
   std::string* str;
 };
 
+#ifndef DMLC_GLOG_DEFINED
+  
 #define DEFINE_CHECK_FUNC(name, op)                               \
   template <typename X, typename Y>                               \
   inline LogCheckError LogCheck##name(const X& x, const Y& y) {   \
@@ -170,6 +172,8 @@ DEFINE_CHECK_FUNC(_NE, !=)
 
 // Poor man version of LOG_EVERY_N
 #define LOG_EVERY_N(severity, n) LOG(severity)
+
+#endif // DMLC_GLOG_DEFINED
 
 class DateLogger {
  public:


### PR DESCRIPTION
Multiple systems like to redefine the GLOG-style macros and they don't play nicely together.
Add a variable to disable their definition.