### PR TITLE
explicit call beforefirst when start producer thread

### DIFF
--- a/include/dmlc/threadediter.h
+++ b/include/dmlc/threadediter.h
@@ -288,6 +288,7 @@ Init(std::function<bool(DType **)> next,
   // procedure running in prodcuer
   // run producer thread
   auto producer_fun = [this, next, beforefirst] () {
+    beforefirst();
     while (true) {
       DType *cell = NULL;
       {


### PR DESCRIPTION
I implement a custom dataloader, it take me a lot of debug. finnaly I found what cause the bug.

the usage of my dataloader in cpp-package:

```cpp
//auto train_iter  = ... (init code)
train_iter.Reset(); //which will call beforefirst
while(train_iter.Next()) {
    auto data_batch = train_iter.GetDataBatch();
}
```

in the above code, I reset the iter, and then start to load data. It seems no problem, right?

But in fact, the `Reset()` is just to send a signal, it don't guarantee to call `beforefirst` before `Next()` function. so I get empty data.

In most case, this bug will no occur. because people use the builtin data iterator. And in this case, dataloader will be init properly. But,  in my case, I put some member variable init in `beforefirst`...

It is better to add `beforefirst` in the producer function, so it will be more fault tolerant.