### PR TITLE
Fix compilation error on MacOS

### DIFF
--- a/include/dmlc/thread_local.h
+++ b/include/dmlc/thread_local.h
@@ -23,7 +23,7 @@ namespace dmlc {
 #endif
 
 #if DMLC_CXX11_THREAD_LOCAL == 0
-#pragma message("Warning: CXX11 thread_local is not formally supported");
+#pragma message("Warning: CXX11 thread_local is not formally supported")
 #endif
 
 /*!


### PR DESCRIPTION
Compiling the library on MacOS fails with
"Pragma message requires parenthesized string".

Removal of a semicolon at the end of a "pragma message" fixes the compilation.

Compiler:
Apple LLVM version 6.0 (clang-600.0.51) (based on LLVM 3.5svn)