### PR TITLE
[BUILD] Fix header file omp.h to match original omp.h

### DIFF
--- a/include/dmlc/omp.h
+++ b/include/dmlc/omp.h
@@ -15,11 +15,20 @@
                 "Use OpenMP-enabled compiler to get benefit of multi-threading.")
 #endif
 //! \cond Doxygen_Suppress
-inline int omp_get_thread_num() { return 0; }
-inline int omp_get_num_threads() { return 1; }
-inline int omp_get_max_threads() { return 1; }
-inline int omp_get_num_procs() { return 1; }
-inline void omp_set_num_threads(int nthread) {}
+#ifdef __cplusplus
+extern "C" {
+# define __GOMP_NOTHROW throw ()
+#else
+# define __GOMP_NOTHROW __attribute__((__nothrow__))
+#endif
+inline int omp_get_thread_num() __GOMP_NOTHROW { return 0; }
+inline int omp_get_num_threads() __GOMP_NOTHROW { return 1; }
+inline int omp_get_max_threads() __GOMP_NOTHROW { return 1; }
+inline int omp_get_num_procs() __GOMP_NOTHROW { return 1; }
+inline void omp_set_num_threads(int nthread) __GOMP_NOTHROW {}
+#ifdef __cplusplus
+}
+#endif
 #endif
 // loop variable used in openmp
 namespace dmlc {


### PR DESCRIPTION
This fixes bug reported in XGBoost project: https://github.com/dmlc/xgboost/issues/2219

The issue can be easily reproduced by the following steps:

```
git clone https://github.com/dmlc/xgboost.git
cd xgboost
docker run -u $(id -u):$(id -g) -v $(pwd):/work -it --rm alanfranz/fwd-centos-7:latest
```

Now, inside docker perform build without OMP:
```
 # Note: `g++ --version` inside container returns:
 #     g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)
 cd /work && make USE_OPENMP=0
```

This will fail on:
```
/usr/lib/gcc/x86_64-redhat-linux/4.8.5/include/omp.h:66:37: error: declaration of 'int omp_get_num_procs() throw ()' has a different exception specifier
In file included from include/xgboost/./base.h:10:0,
                 from include/xgboost/logging.h:13,
                 from src/logging.cc:7:
dmlc-core/include/dmlc/omp.h:21:12: error: from previous declaration 'int omp_get_num_procs()'
 inline int omp_get_num_procs() { return 1; }
            ^
```