### PR TITLE
Added support for optional<bool> parameters.

### DIFF
--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -217,6 +217,7 @@ inline std::istream &operator>>(std::istream &is, optional<bool> &t) {
 
 /*! \brief description for optional int */
 DMLC_DECLARE_TYPE_NAME(optional<int>, "int or None");
+/*! \brief description for optional bool */
 DMLC_DECLARE_TYPE_NAME(optional<bool>, "boolean or None");
 
 }  // namespace dmlc

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -7,6 +7,7 @@
 #define DMLC_OPTIONAL_H_
 
 #include <iostream>
+#include <string>
 #include <utility>
 #include <algorithm>
 
@@ -107,6 +108,8 @@ class optional {
   }
   /*! \brief whether this object is holding a value */
   explicit operator bool() const { return !is_none; }
+  /*! \brief alternate, more-explicit check of object value */
+  const bool IsNone() const { return is_none; }
 
  private:
   // whether this is none
@@ -173,9 +176,48 @@ std::istream &operator>>(std::istream &is, optional<T> &t) {
   }
   return is;
 }
+/*! \brief specialization of '>>' istream parsing for optional<bool>
+ *
+ * Permits use of generic parameter FieldEntry<DType> class to create
+ * FieldEntry<optional<bool>> without explicit specialization.
+ *
+ *  \code
+ *    dmlc::optional<bool> x;
+ *    std::string s1 = "true";
+ *    std::istringstream is1(s1);
+ *    s1 >> x;  // x == optional<bool>(true)
+ *
+ *    std::string s2 = "None";
+ *    std::istringstream is2(s2);
+ *    s2 >> x;  // x == optional<bool>()
+ *  \endcode
+ *
+ *  \param is input stream
+ *  \param t target optional<bool> object
+ *  \return input stream
+ */
+inline std::istream &operator>>(std::istream &is, optional<bool> &t) {
+  std::string s;
+  is >> s;
+
+  if (!is.fail()) {
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
+    if (s == "1" || s == "true")
+      t = true;
+    else if (s == "0" || s == "false")
+      t = false;
+    else if (s == "none")
+      t = nullopt;
+    else
+      is.setstate(std::ios::failbit);
+  }
+
+  return is;
+}
 
 /*! \brief description for optional int */
 DMLC_DECLARE_TYPE_NAME(optional<int>, "int or None");
+DMLC_DECLARE_TYPE_NAME(optional<bool>, "boolean or None");
 
 }  // namespace dmlc
 

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -108,8 +108,8 @@ class optional {
   }
   /*! \brief whether this object is holding a value */
   explicit operator bool() const { return !is_none; }
-  /*! \brief alternate, more-explicit check of object value */
-  bool IsNone() const { return is_none; }
+  /*! \brief whether this object is holding a value (alternate form). */
+  bool has_value() const { return operator bool(); }
 
  private:
   // whether this is none
@@ -197,8 +197,14 @@ std::istream &operator>>(std::istream &is, optional<T> &t) {
  *  \return input stream
  */
 inline std::istream &operator>>(std::istream &is, optional<bool> &t) {
+  // Discard initial whitespace
+  while (isspace(is.peek()))
+    is.get();
+  // Extract chars that might be valid into a separate string, stopping
+  // on whitespace or other non-alphanumerics such as ",)]".
   std::string s;
-  is >> s;
+  while (isalnum(is.peek()))
+    s.push_back(is.get());
 
   if (!is.fail()) {
     std::transform(s.begin(), s.end(), s.begin(), ::tolower);

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -109,7 +109,7 @@ class optional {
   /*! \brief whether this object is holding a value */
   explicit operator bool() const { return !is_none; }
   /*! \brief alternate, more-explicit check of object value */
-  const bool IsNone() const { return is_none; }
+  bool IsNone() const { return is_none; }
 
  private:
   // whether this is none

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 
-TEST(Optional, basics) {
+TEST(Optional, basics_int) {
   dmlc::optional<int> x;
   CHECK(!bool(x));
   x = 1;
@@ -23,7 +23,7 @@ TEST(Optional, basics) {
   CHECK_EQ(y.value(), 1);
 }
 
-TEST(Optional, parsing) {
+TEST(Optional, parsing_int) {
   dmlc::optional<int> x;
   {
     std::ostringstream os;
@@ -53,13 +53,13 @@ TEST(Optional, parsing) {
   }
 }
 
-struct OptionalParam : public dmlc::Parameter<OptionalParam> {
+struct OptionalParamInt : public dmlc::Parameter<OptionalParamInt> {
   dmlc::optional<int> none;
   dmlc::optional<int> one;
   dmlc::optional<int> long_one;
   dmlc::optional<int> def;
 
-  DMLC_DECLARE_PARAMETER(OptionalParam) {
+  DMLC_DECLARE_PARAMETER(OptionalParamInt) {
     DMLC_DECLARE_FIELD(none)
     .add_enum("one", 1);
     DMLC_DECLARE_FIELD(one)
@@ -71,10 +71,10 @@ struct OptionalParam : public dmlc::Parameter<OptionalParam> {
   }
 };
 
-DMLC_REGISTER_PARAMETER(OptionalParam);
+DMLC_REGISTER_PARAMETER(OptionalParamInt);
 
-TEST(Optional, add_enum) {
-  OptionalParam param;
+TEST(Optional, add_enum_int) {
+  OptionalParamInt param;
   std::map<std::string, std::string> kwargs;
   kwargs["none"] = "None";
   kwargs["one"] = "one";
@@ -84,4 +84,114 @@ TEST(Optional, add_enum) {
   CHECK_EQ(param.one.value(), 1);
   CHECK_EQ(param.long_one.value(), 1);
   CHECK(!param.def);
+}
+
+// Repeat above tests, but now testing optional<bool> rather than optional<int>
+
+TEST(Optional, basics_bool) {
+  dmlc::optional<bool> x;
+  CHECK(!bool(x));
+  x = true;
+  CHECK(bool(x));
+  CHECK_EQ(x.value(), true);
+  x = dmlc::nullopt;
+  CHECK(!bool(x));
+  x = true;
+  dmlc::optional<bool> y;
+  y = x;
+  CHECK_EQ(y.value(), true);
+  x = false;
+  y = x;
+  CHECK_EQ(y.value(), false);
+}
+
+TEST(Optional, parsing_bool) {
+  dmlc::optional<bool> x;
+  {
+    std::ostringstream os;
+    os << x;
+    CHECK_EQ(os.str(), "None");
+  }
+
+  {
+    x = true;
+    std::ostringstream os;
+    os << x;
+    CHECK_EQ(os.str(), "1");
+  }
+
+  {
+    x = false;
+    std::ostringstream os;
+    os << x;
+    CHECK_EQ(os.str(), "0");
+  }
+
+  {
+    std::string none("None");
+    std::istringstream is(none);
+    is >> x;
+    CHECK(!bool(x));
+  }
+
+  {
+    std::string one("1");
+    std::istringstream is(one);
+    is >> x;
+    CHECK_EQ(x.value(), 1);
+  }
+
+  {
+    std::string zero("0");
+    std::istringstream is(zero);
+    is >> x;
+    CHECK_EQ(x.value(), 0);
+  }
+
+  {
+    std::string one("true");
+    std::istringstream is(one);
+    is >> x;
+    CHECK_EQ(x.value(), 1);
+  }
+
+  {
+    std::string zero("false");
+    std::istringstream is(zero);
+    is >> x;
+    CHECK_EQ(x.value(), 0);
+  }
+}
+
+struct OptionalParamBool : public dmlc::Parameter<OptionalParamBool> {
+  dmlc::optional<bool> none;
+  dmlc::optional<bool> none_with_default;
+
+  DMLC_DECLARE_PARAMETER(OptionalParamBool) {
+    DMLC_DECLARE_FIELD(none);
+    DMLC_DECLARE_FIELD(none_with_default)
+    .set_default(dmlc::optional<bool>());
+    DMLC_DECLARE_FIELD(set_to_none);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(OptionalParamBool);
+
+TEST(Optional, bool_in_struct) {
+  OptionalParamBool param;
+  CHECK(!param.none());
+  // With optional<bool>, the following explicit approach avoids confusion.
+  CHECK(param.none.IsNone());
+  CHECK(!param.none_with_default);
+  std::map<std::string, std::string> kwargs;
+  // Assign new logical values, testing string assignment
+  kwargs["none"] = "0";
+  kwargs["none_with_default"] = "true";
+  kwargs["set_to_none"] = "None";
+  param.Init(kwargs);
+  CHECK(param.none);
+  CHECK(!param.none.value());
+  CHECK(param.none_with_default);
+  CHECK(param.none_with_default.value());
+  CHECK(param.set_to_none.IsNone());
 }

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -107,6 +107,7 @@ TEST(Optional, basics_bool) {
 
 TEST(Optional, parsing_bool) {
   dmlc::optional<bool> x;
+  dmlc::optional<bool> y;
   {
     std::ostringstream os;
     os << x;
@@ -160,6 +161,13 @@ TEST(Optional, parsing_bool) {
     std::istringstream is(zero);
     is >> x;
     CHECK_EQ(x.value(), 0);
+  }
+
+  {
+    std::istringstream is("false true");
+    is >> x >> y;
+    CHECK_EQ(x.value(), 0);
+    CHECK_EQ(y.value(), 1);
   }
 }
 

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -166,6 +166,7 @@ TEST(Optional, parsing_bool) {
 struct OptionalParamBool : public dmlc::Parameter<OptionalParamBool> {
   dmlc::optional<bool> none;
   dmlc::optional<bool> none_with_default;
+  dmlc::optional<bool> set_to_none;
 
   DMLC_DECLARE_PARAMETER(OptionalParamBool) {
     DMLC_DECLARE_FIELD(none);
@@ -179,7 +180,7 @@ DMLC_REGISTER_PARAMETER(OptionalParamBool);
 
 TEST(Optional, bool_in_struct) {
   OptionalParamBool param;
-  CHECK(!param.none());
+  CHECK(!param.none);
   // With optional<bool>, the following explicit approach avoids confusion.
   CHECK(param.none.IsNone());
   CHECK(!param.none_with_default);

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -190,7 +190,7 @@ TEST(Optional, bool_in_struct) {
   OptionalParamBool param;
   CHECK(!param.none);
   // With optional<bool>, the following explicit approach avoids confusion.
-  CHECK(param.none.IsNone());
+  CHECK(!param.none.has_value());
   CHECK(!param.none_with_default);
   std::map<std::string, std::string> kwargs;
   // Assign new logical values, testing string assignment
@@ -202,5 +202,5 @@ TEST(Optional, bool_in_struct) {
   CHECK(!param.none.value());
   CHECK(param.none_with_default);
   CHECK(param.none_with_default.value());
-  CHECK(param.set_to_none.IsNone());
+  CHECK(!param.set_to_none.has_value());
 }


### PR DESCRIPTION
The following adds the hooks to permit optional bool parameters, used as in:
  dmlc::optional&lt;bool&gt; my_bool;
  ...
  DMLC_DECLARE_FIELD(my_bool)
        .set_default(dmlc::optional&lt;bool&gt;())
        .describe("My optional bool parameter.  User can set to 0/1/true/false, defaults to 'None'");
