### PR TITLE
Reintroducing threaded prefetching to reader

### DIFF
--- a/src/io.cc
+++ b/src/io.cc
@@ -11,6 +11,7 @@
 #include "io/filesys.h"
 #include "io/local_filesys.h"
 #include "io/cached_input_split.h"
+#include "io/threaded_input_split.h"
 
 #if DMLC_USE_HDFS
 #include "io/hdfs_filesys.h"
@@ -83,7 +84,7 @@ InputSplit* InputSplit::Create(const char *uri_,
   }
 #if DMLC_ENABLE_STD_THREAD
   if (spec.cache_file.length() == 0) {
-    return split;
+    return new ThreadedInputSplit(split);
   } else {
     return new CachedInputSplit(split, spec.cache_file.c_str());
   }

--- a/src/io/threaded_input_split.h
+++ b/src/io/threaded_input_split.h
@@ -29,7 +29,7 @@ class ThreadedInputSplit : public InputSplit {
   explicit ThreadedInputSplit(InputSplitBase *base)
       : buffer_size_(InputSplitBase::kBufferSize),
         base_(base), tmp_chunk_(NULL) {
-    iter_.set_max_capacity(8);
+    iter_.set_max_capacity(2);
     // initalize the iterator
     iter_.Init([this](InputSplitBase::Chunk **dptr) {
         if (*dptr == NULL) {
@@ -75,6 +75,16 @@ class ThreadedInputSplit : public InputSplit {
       if (!iter_.Next(&tmp_chunk_)) return false;
     }
     return true;
+  }
+
+  virtual size_t GetTotalSize(void) {
+    return base_->GetTotalSize();
+  }
+
+  virtual void ResetPartition(unsigned part_index, unsigned num_parts)
+  {
+    base_->ResetPartition(part_index, num_parts);
+    this->BeforeFirst();
   }
 
  private:

--- a/src/io/threaded_input_split.h
+++ b/src/io/threaded_input_split.h
@@ -81,8 +81,7 @@ class ThreadedInputSplit : public InputSplit {
     return base_->GetTotalSize();
   }
 
-  virtual void ResetPartition(unsigned part_index, unsigned num_parts)
-  {
+  virtual void ResetPartition(unsigned part_index, unsigned num_parts) {
     base_->ResetPartition(part_index, num_parts);
     this->BeforeFirst();
   }


### PR DESCRIPTION
With the improved IO pipeline in MXNet reading from disk started to become quite big issue. That is why this commit reintroduces the threaded prefetching to InputSplit, while at the same time setting max capacity to 2 in order to conserve memory. In my test I did not really see any difference in memory consumption between current and proposed version, while IO speed improved by ~20% (480px images, quality 95, random resize, crop, mirror for augmentations).
Having IO prefetched also makes it possible to use more time for it to e.g. perform better shuffling (cost of random seek is hidden by the rest of the IO pipeline).