### PR TITLE
Correct the comparison of type_info

### DIFF
--- a/include/dmlc/any.h
+++ b/include/dmlc/any.h
@@ -286,7 +286,7 @@ inline void any::check_type() const {
   CHECK(type_ != nullptr)
       << "The any container is empty"
       << " requested=" << typeid(T).name();
-  CHECK(type_->ptype_info == &typeid(T))
+  CHECK(*(type_->ptype_info) == typeid(T))
       << "The stored type mismatch"
       << " stored=" << type_->ptype_info->name()
       << " requested=" << typeid(T).name();


### PR DESCRIPTION
Comparing two type_info by their address is a wrong usage and will fail in some corner cases, especially if your library is dynamically linked. Here is an error message I got:

terminate called after throwing an instance of 'dmlc::Error'
  what():  [00:31:48] /opt/mxnet/dmlc-core/include/dmlc/any.h:269: Check failed: type_->ptype_info == &typeid(T) The stored type mismatch stored=St6vectorIN4nnvm6TShapeESaIS1_EE requested=St6vectorIN4nnvm6TShapeESaIS1_EE
