### PR TITLE
Adds basic SLURM functionalities, tested with SLURM v16.

### DIFF
--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -70,7 +70,7 @@ def get_opts(args=None):
     """
     parser = argparse.ArgumentParser(description='DMLC job submission.')
     parser.add_argument('--cluster', type=str,
-                        choices=['yarn', 'mpi', 'sge', 'local', 'ssh', 'mesos'],
+                        choices=['yarn', 'slurm', 'mpi', 'sge', 'local', 'ssh', 'mesos'],
                         help=('Cluster type of this submission,' +
                               'default to env variable ${DMLC_SUBMIT_CLUSTER}.'))
     parser.add_argument('--num-workers', required=True, type=int,
@@ -141,6 +141,12 @@ def get_opts(args=None):
                         directory into remote machines\'s SYNC_DST_DIR')
     parser.add_argument('command', nargs='+',
                         help='Command to be launched')
+    parser.add_argument('--slurm-worker-nodes', default=None, type=int,
+                        help=('Number of nodes on which workers are run. Used only in SLURM mode.' +
+                              'If not explicitly set, it defaults to number of workers.'))
+    parser.add_argument('--slurm-server-nodes', default=None, type=int,
+                        help=('Number of nodes on which parameter servers are run. Used only in SLURM mode.' +
+                              'If not explicitly set, it defaults to number of parameter servers.'))
     (args, unknown) = parser.parse_known_args(args)
     args.command += unknown
 

--- a/tracker/dmlc_tracker/slurm.py
+++ b/tracker/dmlc_tracker/slurm.py
@@ -60,6 +60,6 @@ def submit(args):
           thread.start()
 
 
-        tracker.submit(args.num_workers, args.num_servers,
-                       fun_submit=mpi_submit,
-                       pscmd=(' '.join(args.command)))
+    tracker.submit(args.num_workers, args.num_servers,
+                   fun_submit=mpi_submit,
+                   pscmd=(' '.join(args.command)))

--- a/tracker/dmlc_tracker/slurm.py
+++ b/tracker/dmlc_tracker/slurm.py
@@ -1,0 +1,65 @@
+"""
+DMLC submission script, SLURM version
+"""
+# pylint: disable=invalid-name
+from __future__ import absolute_import
+
+import subprocess, logging
+from threading import Thread
+from . import tracker
+
+def get_mpi_env(envs):
+    """get the slurm command for setting the environment
+    """
+    cmd = ''
+    for k, v in envs.items():
+        cmd += '%s=%s ' % (k, str(v))
+    return cmd
+
+
+def submit(args):
+    """Submission script with SLURM."""
+    def mpi_submit(nworker, nserver, pass_envs):
+        """Internal closure for job submission."""
+        def run(prog):
+            """run the program"""
+            subprocess.check_call(prog, shell=True)
+
+        cmd = ' '.join(args.command)
+
+        pass_envs['DMLC_JOB_CLUSTER'] = 'slurm'
+
+        if args.slurm_worker_nodes is None:
+	  nworker_nodes = nworker
+        else:
+          nworker_nodes=args.slurm_worker_nodes
+ 
+
+        # start workers
+        if nworker > 0:
+          logging.info('Start %d workers by srun' % nworker)
+          pass_envs['DMLC_ROLE'] = 'worker'
+          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nworker_nodes, nworker, cmd)
+          thread = Thread(target=run, args=(prog,))
+          thread.setDaemon(True)
+          thread.start()
+
+
+        if args.slurm_server_nodes is None:
+	  nserver_nodes = nserver
+        else:
+          nserver_nodes=args.slurm_server_nodes
+
+        # start servers
+        if nserver > 0:
+          logging.info('Start %d servers by srun' % nserver)
+          pass_envs['DMLC_ROLE'] = 'server'
+          prog = '%s srun --share --exclusive=user -N %d -n %d %s' % (get_mpi_env(pass_envs), nserver_nodes, nserver, cmd)
+          thread = Thread(target=run, args=(prog,))
+          thread.setDaemon(True)
+          thread.start()
+
+
+        tracker.submit(args.num_workers, args.num_servers,
+                       fun_submit=mpi_submit,
+                       pscmd=(' '.join(args.command)))


### PR DESCRIPTION
I created a module to run programs with [SLURM](https://slurm.schedmd.com/). If the pull request is accepted, then I can also update the MXNet tools/launch.py file to enclose these changes.
In SLURM, you first request resources (with `sbatch` or `salloc`) and then consume them (typically by running the program prepending `srun` and some options). For this reason, I added the possibility to choose how many nodes should be used for workers and servers, as some users might want to have workers and servers on different nodes, and the nodes might belong to a subset of the allocated nodes (e.g. allocate 8 nodes, run 8 workers on the first 4 nodes and 8 parameter servers on other 4 nodes).