### PR TITLE
add LIBRARY DESTINATION lib to install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if(INSTALL_INCLUDE_DIR)
 endif()
 
 # ---[ Install the archive static lib and header files
-install(TARGETS dmlc ARCHIVE DESTINATION lib) 
+install(TARGETS dmlc ARCHIVE DESTINATION lib LIBRARY DESTINATION lib) 
 install(DIRECTORY include DESTINATION .)
 install(DIRECTORY doc DESTINATION .)
 


### PR DESCRIPTION
Getting 'TARGETS given no LIBRARY DESTINATION for shared library target' error, when
using dmlc-core as submodule for mxnet as submodule in a project using -DBUILD_SHARED_LIBS=1.
This patch should fix it.