### PR TITLE
tar uncompression bug fix

### DIFF
--- a/tracker/dmlc_tracker/launcher.py
+++ b/tracker/dmlc_tracker/launcher.py
@@ -13,7 +13,7 @@ def unzip_archives(ar_list, env):
         if fname.endswith('.zip'):
             subprocess.call(args=['unzip', fname], env=env)
         elif fname.find('.tar') != -1:
-            subprocess.call(args=['tar', 'xf', fname], env=env)
+            subprocess.call(args=['tar', '-xf', fname], env=env)
 
 def main():
     """Main moduke of the launcher."""


### PR DESCRIPTION
fix bug
```
tar: You must specify one of the `-Acdtrux' or `--test-label'  options
Try `tar --help' or `tar --usage' for more information.
```

@tqchen 