### PR TITLE
dmlc_tracker.ssh.submit() should honor --host-ip option

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -82,4 +82,5 @@ def submit(args):
 
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=ssh_submit,
-                   pscmd=(' '.join(args.command)))
+                   pscmd=(' '.join(args.command)),
+                   hostIP=args.host_ip)


### PR DESCRIPTION
The `DMLC_INTERFACE` env var doesn't seem to affect the address published for the scheduler.  It looked like the `--host-ip` option would work instead.  The ssh driver did not honor it, but that is an easy fix.