### PR TITLE
Small param bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,3 +142,7 @@ if(MSVC)
 endif()
 set(LINT_DIRS include src scripts)
 add_custom_target(dmlc_lint COMMAND ${CMAKE_COMMAND} -DMSVC=${MSVC} -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}  -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR} -DLINT_DIRS=${LINT_DIRS} -DPROJECT_NAME=dmlc -P ${PROJECT_SOURCE_DIR}/cmake/lint.cmake)
+
+# Setup testing
+include(CTest)
+add_subdirectory(test/unittest)

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -985,6 +985,10 @@ class FieldEntry<float> : public FieldEntryNumeric<FieldEntry<float>, float> {
       os << "Invalid Parameter format for " << key_ << " expect " << type_
          << " but value=\'" << value << '\'';
       throw dmlc::ParamError(os.str());
+    } catch (const std::out_of_range) {
+      std::ostringstream os;
+      os << "Out of range value for " << key_ << ", value=\'" << value << '\'';
+      throw dmlc::ParamError(os.str());
     }
   }
 };
@@ -1005,6 +1009,10 @@ class FieldEntry<double>
       std::ostringstream os;
       os << "Invalid Parameter format for " << key_ << " expect " << type_
          << " but value=\'" << value << '\'';
+      throw dmlc::ParamError(os.str());
+    } catch (const std::out_of_range) {
+      std::ostringstream os;
+      os << "Out of range value for " << key_ << ", value=\'" << value << '\'';
       throw dmlc::ParamError(os.str());
     }
   }

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ---[ Google Test
+if(NOT GTEST_ROOT)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+        set(GTEST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
+        set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+        set(GTEST_FOUND ON)
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/gtest")
+        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/gtest")
+        set(GTEST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/gtest")
+        set(GTEST_BOTH_LIBRARIES gtest gtest_main)
+        set(GTEST_FOUND ON)
+    else()
+        find_package(GTest)
+    endif()
+endif()
+
+if(GTEST_FOUND)
+    enable_testing()
+    file(GLOB_RECURSE UNIT_TEST_SOURCE "*.cc")
+    include_directories(cpp/include)
+    add_executable(${PROJECT_NAME}_unit_tests ${UNIT_TEST_SOURCE})
+    set_property(TARGET ${PROJECT_NAME}_unit_tests
+            PROPERTY RUNTIME_OUTPUT_DIRECTORY ${PRIVATE_RUNTIME_DIR})
+    target_link_libraries(${PROJECT_NAME}_unit_tests
+            ${GTEST_LIBRARY}
+            dmlc
+            )
+    add_test(AllTestsIn${PROJECT_NAME}UnitTests ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}_unit_tests)
+else()
+    message(WARNING "Google Test not found")
+endif()

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -71,15 +71,6 @@ struct OptionalParamInt : public dmlc::Parameter<OptionalParamInt> {
 
 DMLC_REGISTER_PARAMETER(OptionalParamInt);
 
-struct LearningRateParam : public dmlc::Parameter<LearningRateParam> {
-  float learning_rate;
-  DMLC_DECLARE_PARAMETER(LearningRateParam) {
-    DMLC_DECLARE_FIELD(learning_rate).set_default(0.01);
-  }
-};
-
-DMLC_REGISTER_PARAMETER(LearningRateParam);
-
 TEST(Optional, add_enum_int) {
   OptionalParamInt param;
   std::map<std::string, std::string> kwargs;
@@ -110,16 +101,6 @@ TEST(Optional, basics_bool) {
   x = false;
   y = x;
   CHECK_EQ(y.value(), false);
-}
-
-TEST(Optional, parsing_small_float) {
-  LearningRateParam param;
-  std::map<std::string, std::string> kwargs;
-  kwargs["learning_rate"] = "9.4039548065783e-39";
-  EXPECT_THROW(
-      param.Init(kwargs),
-      dmlc::ParamError
-  );
 }
 
 TEST(Optional, parsing_bool) {

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -2,8 +2,6 @@
 
 #include <iostream>
 #include <vector>
-#include <string>
-#include <memory>
 #include <dmlc/optional.h>
 #include <dmlc/parameter.h>
 #include <gtest/gtest.h>
@@ -73,6 +71,15 @@ struct OptionalParamInt : public dmlc::Parameter<OptionalParamInt> {
 
 DMLC_REGISTER_PARAMETER(OptionalParamInt);
 
+struct LearningRateParam : public dmlc::Parameter<LearningRateParam> {
+  float learning_rate;
+  DMLC_DECLARE_PARAMETER(LearningRateParam) {
+    DMLC_DECLARE_FIELD(learning_rate).set_default(0.01);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(LearningRateParam);
+
 TEST(Optional, add_enum_int) {
   OptionalParamInt param;
   std::map<std::string, std::string> kwargs;
@@ -103,6 +110,16 @@ TEST(Optional, basics_bool) {
   x = false;
   y = x;
   CHECK_EQ(y.value(), false);
+}
+
+TEST(Optional, parsing_small_float) {
+  LearningRateParam param;
+  std::map<std::string, std::string> kwargs;
+  kwargs["learning_rate"] = "9.4039548065783e-39";
+  EXPECT_THROW(
+      param.Init(kwargs),
+      dmlc::ParamError
+  );
 }
 
 TEST(Optional, parsing_bool) {

--- a/test/unittest/unittest_param.cc
+++ b/test/unittest/unittest_param.cc
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <dmlc/parameter.h>
+
+struct LearningRateParam : public dmlc::Parameter<LearningRateParam> {
+  float learning_rate;
+  DMLC_DECLARE_PARAMETER(LearningRateParam) {
+      DMLC_DECLARE_FIELD(learning_rate).set_default(0.01);
+  }
+};
+
+DMLC_REGISTER_PARAMETER(LearningRateParam);
+
+TEST(Parameter, parsing_small_float) {
+  LearningRateParam param;
+  std::map<std::string, std::string> kwargs;
+  kwargs["learning_rate"] = "9.4039548065783e-39";
+  EXPECT_THROW(
+      param.Init(kwargs),
+      dmlc::ParamError
+  );
+}


### PR DESCRIPTION
This fixes a small issue I've run across when using a very small learning rate.  When param values are out of range for the stof or stod functions we're throwing an out of range exception and bypassing dmlc::ParamError handling.  

I've also enabled builds for the unit test suite for dmlc-core from cmake with this PR.  I've modeled most of those changes on the CMake files from mxnet.

Testing done: make lint, make doc, make test, cmake, ./dmlc_unittest
@larroy 