### PR TITLE
Type name error

### DIFF
--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -233,6 +233,8 @@ DMLC_DECLARE_TYPE_NAME(optional<int>, "int or None");
 DMLC_DECLARE_TYPE_NAME(optional<bool>, "boolean or None");
 /*! \brief description for optional float */
 DMLC_DECLARE_TYPE_NAME(optional<float>, "float or None");
+/*! \brief description for optional double */
+DMLC_DECLARE_TYPE_NAME(optional<double>, "double or None");
 
 }  // namespace dmlc
 

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -231,6 +231,8 @@ inline std::istream &operator>>(std::istream &is, optional<bool> &t) {
 DMLC_DECLARE_TYPE_NAME(optional<int>, "int or None");
 /*! \brief description for optional bool */
 DMLC_DECLARE_TYPE_NAME(optional<bool>, "boolean or None");
+/*! \brief description for optional float */
+DMLC_DECLARE_TYPE_NAME(optional<float>, "float or None");
 
 }  // namespace dmlc
 

--- a/include/dmlc/type_traits.h
+++ b/include/dmlc/type_traits.h
@@ -175,6 +175,7 @@ DMLC_DECLARE_TYPE_NAME(uint32_t, "int (non-negative)");
 DMLC_DECLARE_TYPE_NAME(uint64_t, "long (non-negative)");
 DMLC_DECLARE_TYPE_NAME(std::string, "string");
 DMLC_DECLARE_TYPE_NAME(bool, "boolean");
+DMLC_DECLARE_TYPE_NAME(void*, "ptr");
 
 template<typename Then, typename Else>
 struct IfThenElseType<true, Then, Else> {


### PR DESCRIPTION
With #313 , I fail to build mxnet due to missing type names for `optional<float>` and `void*`. 

```
build/src/operator/tensor/init_op.o: In function `mxnet::op::RangeParam::__DECLARE__(dmlc::parameter::ParamManagerSingleton<mxnet::op::RangeParam>*)':
init_op.cc:(.text._ZN5mxnet2op10RangeParam11__DECLARE__EPN4dmlc9parameter21ParamManagerSingletonIS1_EE[_ZN5mxnet2op10RangeParam11__DECLARE__EPN4dmlc9parameter21ParamManagerSingletonIS1_EE]+0x9a4): undefined reference to `dmlc::type_name_helper<dmlc::optional<float> >::value()'

build/src/operator/custom/ndarray_op.o: In function `mxnet::op::NDArrayOpParam::__MANAGER__()':
ndarray_op.cc:(.text+0x749): undefined reference to `dmlc::type_name_helper<void*>::value()'
```

I checked code and find there is respectively
```
dmlc::optional<real_t> stop;
DMLC_DECLARE_FIELD(stop)
```
in src/operator/tensor/init_op.h and
```
void *info;
DMLC_DECLARE_FIELD(info);
```
in  src/operator/custom/ndarray_op-inl.h