### PR TITLE
Pass additional environment variables when launching a job

### DIFF
--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -69,4 +69,4 @@ def submit(args):
 
     # call submit, with nslave, the commands to run each job and submit function
     tracker.submit(args.num_workers, args.num_servers, fun_submit=mthread_submit,
-                   pscmd=(' '.join(args.command)))
+                   pscmd=(' '.join(args.command)), addnl_envs=args.pass_env)

--- a/tracker/dmlc_tracker/mpi.py
+++ b/tracker/dmlc_tracker/mpi.py
@@ -79,4 +79,5 @@ def submit(args):
 
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=mpi_submit,
-                   pscmd=(' '.join(args.command)))
+                   pscmd=(' '.join(args.command)),
+                   addnl_envs=args.pass_env)

--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -147,6 +147,10 @@ def get_opts(args=None):
     parser.add_argument('--slurm-server-nodes', default=None, type=int,
                         help=('Number of nodes on which parameter servers are run. Used only in SLURM mode.' +
                               'If not explicitly set, it defaults to number of parameter servers.'))
+    parser.add_argument('--pass-env', type=str, default='',
+                        help = 'given a comma separated list of environment \
+                        variables, passes their values while launching job')
+
     (args, unknown) = parser.parse_known_args(args)
     args.command += unknown
 

--- a/tracker/dmlc_tracker/sge.py
+++ b/tracker/dmlc_tracker/sge.py
@@ -45,4 +45,5 @@ def submit(args):
     # call submit, with nslave, the commands to run each job and submit function
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=sge_submit,
-                   pscmd=' '.join(args.command))
+                   pscmd=' '.join(args.command),
+                   addnl_envs=args.pass_env)

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -83,4 +83,5 @@ def submit(args):
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=ssh_submit,
                    pscmd=(' '.join(args.command)),
-                   hostIP=args.host_ip)
+                   hostIP=args.host_ip,
+                   addnl_envs=args.pass_envs)

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -84,4 +84,4 @@ def submit(args):
                    fun_submit=ssh_submit,
                    pscmd=(' '.join(args.command)),
                    hostIP=args.host_ip,
-                   addnl_envs=args.pass_envs)
+                   addnl_envs=args.pass_env)

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -407,12 +407,20 @@ def get_host_ip(hostIP=None):
     return hostIP
 
 
-def submit(nworker, nserver, fun_submit, hostIP='auto', pscmd=None):
+def submit(nworker, nserver, fun_submit, hostIP='auto', pscmd=None, addnl_envs=None):
     if nserver == 0:
         pscmd = None
 
     envs = {'DMLC_NUM_WORKER' : nworker,
             'DMLC_NUM_SERVER' : nserver}
+
+    if addnl_envs:
+        for k in addnl_envs.split(","):
+            try:
+                envs[k] = os.environ[k]
+            except KeyError:
+                print (k + ' is missing from os environment variables')
+
     hostIP = get_host_ip(hostIP)
 
     if nserver == 0:

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -416,10 +416,7 @@ def submit(nworker, nserver, fun_submit, hostIP='auto', pscmd=None, addnl_envs=N
 
     if addnl_envs:
         for k in addnl_envs.split(","):
-            try:
-                envs[k] = os.environ[k]
-            except KeyError:
-                print (k + ' is missing from os environment variables')
+            envs[k] = os.environ[k]
 
     hostIP = get_host_ip(hostIP)
 

--- a/tracker/dmlc_tracker/yarn.py
+++ b/tracker/dmlc_tracker/yarn.py
@@ -126,4 +126,5 @@ def submit(args):
     YARN_BOOT_PY = os.path.join(curr_path, 'launcher.py')
     tracker.submit(args.num_workers, args.num_servers,
                    fun_submit=yarn_submit_pass,
-                   pscmd=(' '.join([YARN_BOOT_PY] + args.command)))
+                   pscmd=(' '.join([YARN_BOOT_PY] + args.command)),
+                   addnl_envs=args.pass_env)


### PR DESCRIPTION
I found it very useful to pass certain additional variables when launching jobs. I've used this for variables like PYTHONPATH, MXNET_ENGINE_TYPE, MXNET_PROFILER_AUTOSTART, etc. 
I think this would be a good addition to the functionality of launcher. 
If you have suggestions for a different name, please let me know. 
The current usage is 
```--pass-env A,B,C```

I've only tested this with local and ssh. Not tested this with yarn, mpi, sge since I don't have those environments set up. But I think this should work even in those environments. Or should I remove them and only support local and ssh?

Provides a way to solve this issue https://github.com/apache/incubator-mxnet/issues/7857