### PR TITLE
Consistent behavior if environment variable is not set or blank

### DIFF
--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -1036,7 +1036,12 @@ template<typename ValueType>
 inline ValueType GetEnv(const char *key,
                         ValueType default_value) {
   const char *val = getenv(key);
-  if (val == NULL) return default_value;
+  // On some implementations, if the var is set to a blank string (i.e. "FOO="), then
+  // a blank string will be returned instead of NULL.  In order to be consistent, if
+  // the environment var is a blank string, then also behave as if a null was returned.
+  if (val == nullptr || !*val) {
+    return default_value;
+  }
   ValueType ret;
   parameter::FieldEntry<ValueType> e;
   e.Init(key, &ret, ret);

--- a/test/unittest/unittest_env.cc
+++ b/test/unittest/unittest_env.cc
@@ -1,0 +1,28 @@
+// Copyright by Contributors
+#include <dmlc/config.h>
+#include <gtest/gtest.h>
+#include <dmlc/parameter.h>
+
+TEST(Env, Blank) {
+  const char *var_name = "test_environment_var__askjaposcjp";
+  ::setenv(var_name, "foo", 1);
+  std::string res = dmlc::GetEnv(var_name, std::string("not_food"));
+  GTEST_ASSERT_EQ(res, "foo");
+  ::setenv(var_name, "bar", 1);
+  res = dmlc::GetEnv(var_name, std::string("bar"));
+  GTEST_ASSERT_EQ(res, "bar");
+  ::putenv(const_cast<char *>((std::string() + var_name + "=").c_str()));
+  const char *s = ::getenv(var_name);  // On Mac, this may return an empty string
+  if (s) {
+    // Some implementations will return an empty string instead of null
+    res = dmlc::GetEnv(var_name, std::string("another_default"));
+    GTEST_ASSERT_EQ(res, "another_default");
+  }
+  ::setenv(var_name, "", 1);
+  s = ::getenv(var_name);  // On Linux, this may return an empty string
+  if (s) {
+    // Some implementations will return an empty string instead of null
+    res = dmlc::GetEnv(var_name, std::string("another_default"));
+    GTEST_ASSERT_EQ(res, "another_default");
+  }
+}


### PR DESCRIPTION
If an environment variable is set to a blank string, some implementations will return NULL, but some will return a blank string.  Apply consistent behavior to return default for either a blank string or a null returned by getenv()