### PR TITLE
dmlc namespace, remove unicode header, reformat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ config.mk
 deps
 recommonmark
 build
+
+# CLion
+.idea

--- a/include/dmlc/blockingconcurrentqueue.h
+++ b/include/dmlc/blockingconcurrentqueue.h
@@ -5,6 +5,9 @@
 // Uses Jeff Preshing's semaphore implementation (under the terms of its
 // separate zlib license, embedded below).
 
+#ifndef DMLC_BLOCKINGCONCURRENTQUEUE_H_
+#define DMLC_BLOCKINGCONCURRENTQUEUE_H_
+
 #pragma once
 
 #include "concurrentqueue.h"
@@ -32,6 +35,8 @@ extern "C" {
 #elif defined(__unix__)
 #include <semaphore.h>
 #endif
+
+namespace dmlc {
 
 namespace moodycamel
 {
@@ -422,7 +427,7 @@ template<typename T, typename Traits = ConcurrentQueueDefaultTraits>
 class BlockingConcurrentQueue
 {
 private:
-	typedef ::moodycamel::ConcurrentQueue<T, Traits> ConcurrentQueue;
+	typedef ::dmlc::moodycamel::ConcurrentQueue<T, Traits> ConcurrentQueue;
 	typedef details::mpmc_sema::LightweightSemaphore LightweightSemaphore;
 
 public:
@@ -980,4 +985,7 @@ inline void swap(BlockingConcurrentQueue<T, Traits>& a, BlockingConcurrentQueue<
 }
 
 }	// end namespace moodycamel
+}  // namespace dmlc
+
+#endif  // DMLC_BLOCKINGCONCURRENTQUEUE_H_
 //! \endcond Doxygen_Suppress

--- a/test/unittest/unittest_lockfree.cc
+++ b/test/unittest/unittest_lockfree.cc
@@ -127,11 +127,11 @@ static void BlockingPullThread(const int id, std::shared_ptr<LFQThreadData<TQueu
 TEST(Lockfree, ConcurrentQueue) {
   ThreadGroup threads;
   const int ITEM_COUNT = 100;
-  auto data = std::make_shared<LFQThreadData<moodycamel::ConcurrentQueue<int>>>();
+  auto data = std::make_shared<LFQThreadData<dmlc::moodycamel::ConcurrentQueue<int>>>();
   for(size_t x = 0; x < ITEM_COUNT; ++x) {
     std::unique_lock<std::mutex> lk(data->cs_map_);
     data->thread_map_.insert(x);
-    threads.Start(PushThread<moodycamel::ConcurrentQueue<int>>, x, data);
+    threads.Start(PushThread<dmlc::moodycamel::ConcurrentQueue<int>>, x, data);
   }
   while(data->count_ < ITEM_COUNT) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
@@ -153,7 +153,7 @@ TEST(Lockfree, ConcurrentQueue) {
   for(size_t x = 0; x < ITEM_COUNT; ++x) {
     std::unique_lock<std::mutex> lk(data->cs_map_);
     data->thread_map_.insert(x);
-    threads.Start(PullThread<moodycamel::ConcurrentQueue<int>>, x, data);
+    threads.Start(PullThread<dmlc::moodycamel::ConcurrentQueue<int>>, x, data);
   }
   data->ready_->signal();
   threads.WaitForAll();
@@ -165,8 +165,8 @@ TEST(Lockfree, ConcurrentQueue) {
 
 TEST(Lockfree, BlockingConcurrentQueue) {
 
-  using BlockingQueue = moodycamel::BlockingConcurrentQueue<
-    int, moodycamel::ConcurrentQueueDefaultTraits>;
+  using BlockingQueue = dmlc::moodycamel::BlockingConcurrentQueue<
+    int, dmlc::moodycamel::ConcurrentQueueDefaultTraits>;
 
   ThreadGroup threads;
   const int ITEM_COUNT = 100;


### PR DESCRIPTION
Fix build problems with amalgamation (UNICODE tag at top of queue headers)
Enclose queues in namespace