### PR TITLE
Demangle symbols on stack traces and errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ list(APPEND SOURCE "src/io/indexed_recordio_split.cc")
 list(APPEND SOURCE "src/io/input_split_base.cc")
 list(APPEND SOURCE "src/io/filesys.cc")
 list(APPEND SOURCE "src/io/local_filesys.cc")
+list(APPEND SOURCE "src/logging.cc")
 
 if(USE_HDFS)
   list(APPEND SOURCE "src/io/hdfs_filesys.cc")

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,9 +41,14 @@
  * \brief Whether to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__)\
+#if (defined(__GNUC__) && !defined(__MINGW32__)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))
+#if (!defined(DMLC_LOG_STACK_TRACE))
 #define DMLC_LOG_STACK_TRACE 1
+#endif
+#if (!defined(DMLC_LOG_STACK_TRACE_SIZE))
+#define DMLC_LOG_STACK_TRACE_SIZE 10
+#endif
 #endif
 
 /*! \brief whether compile with hdfs support */

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1,0 +1,39 @@
+// Copyright by Contributors
+#include <dmlc/base.h>
+#include <dmlc/logging.h>
+#if DMLC_LOG_STACK_TRACE
+#include <cxxabi.h>
+#endif
+using namespace std;
+
+namespace dmlc {
+#if DMLC_LOG_STACK_TRACE
+/// Demangle the first C++ symbol found so stack traces are more legible, mangled C++ start with _Z
+std::string demangle(char const* msg_str) {
+  using namespace std;
+  string msg(msg_str);
+  size_t symbol_start = string::npos;
+  size_t symbol_end = string::npos;
+  if ( ((symbol_start = msg.find("_Z")) != string::npos)
+       && (symbol_end = msg.find_first_of(" ", symbol_start)) ) {
+    string left_of_symbol(msg, 0, symbol_start);
+    string symbol(msg, symbol_start, symbol_end - symbol_start);
+    string right_of_symbol(msg, symbol_end);
+
+    int status = 0;
+    size_t length = string::npos;
+    char* demangled_symbol = abi::__cxa_demangle(symbol.c_str(), 0, &length, &status);
+    if (demangled_symbol && status == 0 && length > 0) {
+      string symbol_str(demangled_symbol, length - 1);
+      free(demangled_symbol);
+      ostringstream os;
+      os << left_of_symbol << symbol_str << right_of_symbol;
+      return os.str();
+    }
+  }
+  return string(msg_str);
+}
+
+
+#endif
+} // namespace dmlc


### PR DESCRIPTION
This improves backtraces with demangled symbols:


For example:

## from:

```

Stack trace returned 7 entries:
[bt] (0) 0   libmxnet.so                         0x000000010190a00e _ZN4dmlc15LogMessageFatalD2Ev + 46
[bt] (1) 1   libmxnet.so                         0x00000001018f46b5 _ZN4dmlc15LogMessageFatalD1Ev + 21
[bt] (2) 2   libmxnet.so                         0x0000000101b719bb _ZN5mxnet10Imperative8InvokeOpERKNS_7ContextERKN4nnvm9NodeAttrsERKNSt3__16vectorIPNS_7NDArrayENS8_9allocatorISB_EEEESG_RKNS9_INS_9OpReqTypeENSC_ISH_EEEENS_12DispatchModeENS_10OpStatePtrE + 3995
[bt] (3) 3   libmxnet.so                         0x0000000101b75b2c _ZN5mxnet10Imperative6InvokeERKNS_7ContextERKN4nnvm9NodeAttrsERKNSt3__16vectorIPNS_7NDArrayENS8_9allocatorISB_EEEESG_ + 1692
[bt] (4) 4   libmxnet.so                         0x00000001019a22b8 _Z22MXImperativeInvokeImplPviPS_PiPS0_iPPKcS5_ + 776
[bt] (5) 5   libmxnet.so                         0x00000001019a4307 MXImperativeInvokeEx + 167
[bt] (6) 6   _ctypes.cpython-36m-darwin.so       0x000000010098643f ffi_call_unix64 + 79

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/pllarroy/devel/mxnet/mxnet_other/python/mxnet/ndarray/ndarray.py", line 2177, in ones
    return _internal._ones(shape=shape, ctx=ctx, dtype=dtype, **kwargs)
  File "<string>", line 34, in _ones
  File "/Users/pllarroy/devel/mxnet/mxnet_other/python/mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "/Users/pllarroy/devel/mxnet/mxnet_other/python/mxnet/base.py", line 146, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [20:25:27] /Users/pllarroy/devel/mxnet/mxnet_other/src/imperative/imperative.cc:78: Operator _ones is not implemented for GPU.

Stack trace returned 7 entries:
[bt] (0) 0   libmxnet.so                         0x000000010190a00e _ZN4dmlc15LogMessageFatalD2Ev + 46
[bt] (1) 1   libmxnet.so                         0x00000001018f46b5 _ZN4dmlc15LogMessageFatalD1Ev + 21
[bt] (2) 2   libmxnet.so                         0x0000000101b719bb _ZN5mxnet10Imperative8InvokeOpERKNS_7ContextERKN4nnvm9NodeAttrsERKNSt3__16vectorIPNS_7NDArrayENS8_9allocatorISB_EEEESG_RKNS9_INS_9OpReqTypeENSC_ISH_EEEENS_12DispatchModeENS_10OpStatePtrE + 3995
[bt] (3) 3   libmxnet.so                         0x0000000101b75b2c _ZN5mxnet10Imperative6InvokeERKNS_7ContextERKN4nnvm9NodeAttrsERKNSt3__16vectorIPNS_7NDArrayENS8_9allocatorISB_EEEESG_ + 1692
[bt] (4) 4   libmxnet.so                         0x00000001019a22b8 _Z22MXImperativeInvokeImplPviPS_PiPS0_iPPKcS5_ + 776
[bt] (5) 5   libmxnet.so                         0x00000001019a4307 MXImperativeInvokeEx + 167
[bt] (6) 6   _ctypes.cpython-36m-darwin.so       0x000000010098643f ffi_call_unix64 + 79
```

## to:
```
Stack trace returned 7 entries:
[bt] (0) 0   libmxnet.so                         0x000000010daf3364 dmlc::LogMessageFatal::~LogMessageFatal() + 1172
[bt] (1) 1   libmxnet.so                         0x000000010dadd5a5 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (2) 2   libmxnet.so                         0x000000010dd5af1b mxnet::Imperative::InvokeOp(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, mxnet::DispatchMode, mxnet::OpStatePtr) + 3995
[bt] (3) 3   libmxnet.so                         0x000000010dd5f08c mxnet::Imperative::Invoke(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&) + 1692
[bt] (4) 4   libmxnet.so                         0x000000010db8b908 MXImperativeInvokeImpl(void*, int, void**, int*, void***, int, char const**, char const**) + 776
[bt] (5) 5   libmxnet.so                         0x000000010db8d957 MXImperativeInvokeEx + 167
[bt] (6) 6   _ctypes.cpython-35m-darwin.so       0x000000010cdae797 ffi_call_unix64 + 79


cerr: [20:25:16] /Users/pllarroy/devel/mxnet/mxnet/src/imperative/imperative.cc:78: Operator _ones is not implemented for GPU.

Stack trace returned 7 entries:
[bt] (0) 0   libmxnet.so                         0x000000010daf3364 dmlc::LogMessageFatal::~LogMessageFatal() + 1172
[bt] (1) 1   libmxnet.so                         0x000000010dadd5a5 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (2) 2   libmxnet.so                         0x000000010dd5af1b mxnet::Imperative::InvokeOp(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, mxnet::DispatchMode, mxnet::OpStatePtr) + 3995
[bt] (3) 3   libmxnet.so                         0x000000010dd5f08c mxnet::Imperative::Invoke(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&) + 1692
[bt] (4) 4   libmxnet.so                         0x000000010db8b908 MXImperativeInvokeImpl(void*, int, void**, int*, void***, int, char const**, char const**) + 776
[bt] (5) 5   libmxnet.so                         0x000000010db8d957 MXImperativeInvokeEx + 167
[bt] (6) 6   _ctypes.cpython-35m-darwin.so       0x000000010cdae797 ffi_call_unix64 + 79


Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/pllarroy/devel/mxnet/mxnet/python/mxnet/ndarray/ndarray.py", line 2177, in ones
    return _internal._ones(shape=shape, ctx=ctx, dtype=dtype, **kwargs)
  File "<string>", line 34, in _ones
  File "/Users/pllarroy/devel/mxnet/mxnet/python/mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "/Users/pllarroy/devel/mxnet/mxnet/python/mxnet/base.py", line 146, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [20:25:16] /Users/pllarroy/devel/mxnet/mxnet/src/imperative/imperative.cc:78: Operator _ones is not implemented for GPU.

Stack trace returned 7 entries:
[bt] (0) 0   libmxnet.so                         0x000000010daf3364 dmlc::LogMessageFatal::~LogMessageFatal() + 1172
[bt] (1) 1   libmxnet.so                         0x000000010dadd5a5 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (2) 2   libmxnet.so                         0x000000010dd5af1b mxnet::Imperative::InvokeOp(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, mxnet::DispatchMode, mxnet::OpStatePtr) + 3995
[bt] (3) 3   libmxnet.so                         0x000000010dd5f08c mxnet::Imperative::Invoke(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&) + 1692
[bt] (4) 4   libmxnet.so                         0x000000010db8b908 MXImperativeInvokeImpl(void*, int, void**, int*, void***, int, char const**, char const**) + 776
[bt] (5) 5   libmxnet.so                         0x000000010db8d957 MXImperativeInvokeEx + 167
[bt] (6) 6   _ctypes.cpython-35m-darwin.so       0x000000010cdae797 ffi_call_unix64 + 79
```