### PR TITLE
Demangle symbols on stack traces and errors (using function)

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -41,9 +41,14 @@
  * \brief Whether to print stack trace for fatal error,
  * enabled on linux when using gcc.
  */
-#if (!defined(DMLC_LOG_STACK_TRACE) && defined(__GNUC__) && !defined(__MINGW32__)\
+#if (defined(__GNUC__) && !defined(__MINGW32__)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))
+#if (!defined(DMLC_LOG_STACK_TRACE))
 #define DMLC_LOG_STACK_TRACE 1
+#endif
+#if (!defined(DMLC_LOG_STACK_TRACE_SIZE))
+#define DMLC_LOG_STACK_TRACE_SIZE 10
+#endif
 #endif
 
 /*! \brief whether compile with hdfs support */


### PR DESCRIPTION
This time using a function:

## result:

```
pllarroy@acbc329d1fbd:0:~/devel/mxnet/mxnet/python$ cp ../cmake-build-debug/libmxnet.so mxnet && python -c "import mxnet as mx;a=mx.nd.ones((10,10),mx.gpu(0))"
/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/numpy/oldnumeric/__init__.py:11: ModuleDeprecationWarning: The oldnumeric module will be dropped in Numpy 1.9
  warnings.warn(_msg, ModuleDeprecationWarning)
[03:25:40] /Users/pllarroy/devel/mxnet/mxnet/src/imperative/./imperative_utils.h:75: GPU support is disabled. Compile MXNet with USE_CUDA=1 to enable GPU support.
[03:25:40] /Users/pllarroy/devel/mxnet/mxnet/dmlc-core/include/dmlc/logging.h:347: [03:25:40] /Users/pllarroy/devel/mxnet/mxnet/src/imperative/imperative.cc:78: Operator _ones is not implemented for GPU.

Stack trace returned 8 entries:
[bt] (0) 0   libmxnet.so                         0x000000010abdfbda dmlc::stack_trace() + 1210
[bt] (1) 1   libmxnet.so                         0x000000010abdf51a dmlc::LogMessageFatal::~LogMessageFatal() + 58
[bt] (2) 2   libmxnet.so                         0x000000010abc9b85 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (3) 3   libmxnet.so                         0x000000010ae5542b mxnet::Imperative::InvokeOp(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, mxnet::DispatchMode, mxnet::OpStatePtr) + 3995
[bt] (4) 4   libmxnet.so                         0x000000010ae5959c mxnet::Imperative::Invoke(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&) + 1692
[bt] (5) 5   libmxnet.so                         0x000000010ac793b8 MXImperativeInvokeImpl(void*, int, void**, int*, void***, int, char const**, char const**) + 776
[bt] (6) 6   libmxnet.so                         0x000000010ac7b407 MXImperativeInvokeEx + 167
[bt] (7) 7   libffi.dylib                        0x00007fff8c0b3f14 ffi_call_unix64 + 76


Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "mxnet/ndarray/ndarray.py", line 2177, in ones
    return _internal._ones(shape=shape, ctx=ctx, dtype=dtype, **kwargs)
  File "<string>", line 34, in _ones
  File "mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "mxnet/base.py", line 146, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [03:25:40] /Users/pllarroy/devel/mxnet/mxnet/src/imperative/imperative.cc:78: Operator _ones is not implemented for GPU.

Stack trace returned 8 entries:
[bt] (0) 0   libmxnet.so                         0x000000010abdfbda dmlc::stack_trace() + 1210
[bt] (1) 1   libmxnet.so                         0x000000010abdf51a dmlc::LogMessageFatal::~LogMessageFatal() + 58
[bt] (2) 2   libmxnet.so                         0x000000010abc9b85 dmlc::LogMessageFatal::~LogMessageFatal() + 21
[bt] (3) 3   libmxnet.so                         0x000000010ae5542b mxnet::Imperative::InvokeOp(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::OpReqType, std::__1::allocator<mxnet::OpReqType> > const&, mxnet::DispatchMode, mxnet::OpStatePtr) + 3995
[bt] (4) 4   libmxnet.so                         0x000000010ae5959c mxnet::Imperative::Invoke(mxnet::Context const&, nnvm::NodeAttrs const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&, std::__1::vector<mxnet::NDArray*, std::__1::allocator<mxnet::NDArray*> > const&) + 1692
[bt] (5) 5   libmxnet.so                         0x000000010ac793b8 MXImperativeInvokeImpl(void*, int, void**, int*, void***, int, char const**, char const**) + 776
[bt] (6) 6   libmxnet.so                         0x000000010ac7b407 MXImperativeInvokeEx + 167
[bt] (7) 7   libffi.dylib                        0x00007fff8c0b3f14 ffi_call_unix64 + 76
```