### PR TITLE
fix csv parser

### DIFF
--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -68,6 +68,7 @@ ParseBlock(char *begin,
   out->Clear();
   char * lbegin = begin;
   char * lend = lbegin;
+  while ((lbegin != end) && (*lbegin == '\n' || *lbegin == '\r')) ++lbegin;
   while (lbegin != end) {
     // get line end
     lend = lbegin + 1;

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -68,6 +68,7 @@ ParseBlock(char *begin,
   out->Clear();
   char * lbegin = begin;
   char * lend = lbegin;
+  // advance lbegin if it points to newlines
   while ((lbegin != end) && (*lbegin == '\n' || *lbegin == '\r')) ++lbegin;
   while (lbegin != end) {
     // get line end


### PR DESCRIPTION
Fix https://github.com/apache/incubator-mxnet/issues/8587 

@tqchen @anirudh2290  

With the following file content:
```
1,2\n
```

The blocks passed from the multi-threaded [text_parser](https://github.com/dmlc/dmlc-core/blob/master/src/data/text_parser.h#L100) include one block from offset 3 to offset 4. In this case, `lbegin` points to `\n` and should be ignored. 
