### PR TITLE
Support to allow user to pass specific environment variables (server/worker/both)

### DIFF
--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -39,7 +39,6 @@ def exec_cmd(cmd, role, taskid, dmlc_envs, addnl_envs):
         env.update(addnl_envs['worker'])
     else:
         env.update(addnl_envs['server'])
-        print(env)
 
     env['DMLC_TASK_ID'] = str(taskid)
     env['DMLC_ROLE'] = role

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -20,10 +20,14 @@ def prepare_envs(args):
     # if --env option was used to pass a variable it would automatically be
     # included because of the next line
     envs['default'] = os.environ.copy()
+
     # given by user
-    for k in args.env:
+    common_envs = [item for item in args.env.split(',') if item]
+    for k in common_envs:
         if k not in envs['default']:
-            raise ValueError('The environment variable '+ k + ' was passed but not set')
+            # raise warning if user intended to set this
+            logging.info('The environment variable %s was passed but not set', k)
+
     envs['server'] = parse_env_pairs(args.env_server)
     envs['worker'] = parse_env_pairs(args.env_worker)
     return envs

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -15,8 +15,10 @@ def prepare_envs(args):
     Load environment variables from arguments
     """
     envs = {}
-    # default env variables passed
-    # would automatically include --envs even if given
+    # envs['default'] refers to the default env variables passed for both worker and server
+
+    # if --env option was used to pass a variable it would automatically be
+    # included because of the next line
     envs['default'] = os.environ.copy()
     # given by user
     for k in args.env:
@@ -76,7 +78,8 @@ def submit(args):
         ----------
         nworker: number of slave process to start up
         nserver: number of server nodes to start up
-        envs: enviroment variables to be added to the starting programs
+        dmlc_envs: refers to the environment variables required to start distributed training
+        addnl_envs: are optional environment variables passed by the user
         """
         procs = {}
         for i in range(nworker + nserver):

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -8,15 +8,33 @@ import subprocess
 import logging
 from threading import Thread
 from . import tracker
+from .opts import parse_env_pairs
 
-def exec_cmd(cmd, role, taskid, pass_env):
+def prepare_envs(args):
+    """
+    Load environment variables from arguments
+    """
+    envs = {}
+    # default env variables passed
+    # would automatically include --envs even if given
+    envs['default'] = os.environ.copy()
+    # given by user
+    envs['server'] = parse_env_pairs(args.envs_server)
+    envs['worker'] = parse_env_pairs(args.envs_worker)
+    return envs
+
+def exec_cmd(cmd, role, taskid, dmlc_envs, addnl_envs):
     """Execute the command line command."""
     if cmd[0].find('/') == -1 and os.path.exists(cmd[0]) and os.name != 'nt':
         cmd[0] = './' + cmd[0]
     cmd = ' '.join(cmd)
-    env = os.environ.copy()
-    for k, v in pass_env.items():
-        env[k] = str(v)
+
+    env = addnl_envs['default']
+    env.update(dmlc_envs)
+    if role == 'worker':
+        env.update(addnl_envs['worker'])
+    else:
+        env.update(addnl_envs['server'])
 
     env['DMLC_TASK_ID'] = str(taskid)
     env['DMLC_ROLE'] = role
@@ -41,10 +59,11 @@ def exec_cmd(cmd, role, taskid, pass_env):
             else:
                 raise RuntimeError('Get nonzero return code=%d on %s %s' % (ret, cmd, env))
 
-
 def submit(args):
     """Submit function of local jobs."""
-    def mthread_submit(nworker, nserver, envs):
+    envs = prepare_envs(args)
+
+    def mthread_submit(nworker, nserver, dmlc_envs, addnl_envs):
         """
         customized submit script, that submit nslave jobs, each must contain args as parameter
         note this can be a lambda function containing additional parameters in input
@@ -61,10 +80,11 @@ def submit(args):
                 role = 'worker'
             else:
                 role = 'server'
-            procs[i] = Thread(target=exec_cmd, args=(args.command, role, i, envs))
+            procs[i] = Thread(target=exec_cmd, args=(args.command, role, i, dmlc_envs, addnl_envs))
             procs[i].setDaemon(True)
             procs[i].start()
 
     # call submit, with nslave, the commands to run each job and submit function
     tracker.submit(args.num_workers, args.num_servers, fun_submit=mthread_submit,
-                   pscmd=(' '.join(args.command)))
+                   pscmd=(' '.join(args.command)),
+                   addnl_envs=envs)

--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -164,14 +164,12 @@ def get_opts(args=None):
                         directory into remote machines\'s SYNC_DST_DIR')
     parser.add_argument('command', nargs='+',
                         help='Command to be launched')
-
     parser.add_argument('--slurm-worker-nodes', default=None, type=int,
                         help=('Number of nodes on which workers are run. Used only in SLURM mode.' +
                               'If not explicitly set, it defaults to number of workers.'))
     parser.add_argument('--slurm-server-nodes', default=None, type=int,
                         help=('Number of nodes on which parameter servers are run. Used only in SLURM mode.' +
                               'If not explicitly set, it defaults to number of parameter servers.'))
-
     parser.add_argument('--kube-namespace', default="default", type=str,
                         help=('A namespace in whitch all tasks are run. Used only in Kubernetes mode.' +
                               'If not explicitly set, it defaults to default.'))

--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -55,10 +55,11 @@ def get_memory_mb(mem_str):
         msg = 'Invalid memory specification %s, need to be a number follows g or m' % mem_str
         raise RuntimeError(msg)
 
-def parse_env_pairs(env_args):
+def parse_env_pairs(env_args_str):
     """
-    Convert a list of key:value to a dictionary
-    Example: `['key1:value1', 'key2:value2']` into a dictionary with 2 keys ('key1' and 'key2')
+    Convert a comma separated list of key:value to a dictionary
+    Example: `'key1:value1,key2:value2'` into a dictionary with 2 keys ('key1' and 'key2')
+    whose values are 'value1' and 'value2' respectively
     :param env_args:
     :return:
     """
@@ -67,9 +68,11 @@ def parse_env_pairs(env_args):
                          ". Expected is env_variable:value")
 
     envs = {}
+
+    env_args = [pair for pair in env_args_str.split(',') if pair]
     for pair in env_args:
         try:
-            k,v = pair.split(":")
+            k, v = pair.split(":")
             envs[k] = v
         except ValueError:
             # to raise an error that user can understand
@@ -141,12 +144,13 @@ def get_opts(args=None):
                               ' but corresponds to archieve files that will be unziped locally,' +
                               ' You can use this option to ship python libraries.' +
                               ' Only valid in yarn jobs.'))
-    parser.add_argument('--env', action='append', default=[],
-                        help='Client and ApplicationMaster environment variables.')
-    parser.add_argument('--env-server', action='append', default=[],
-                        help='Environment variable:value for server only')
-    parser.add_argument('--env-worker', action='append', default=[],
-                        help='Environment variable:value for worker only')
+    parser.add_argument('--env', type=str, default='',
+                        help='Comma separated list of Client and ApplicationMaster environment \
+                        variables.')
+    parser.add_argument('--env-server', type=str, default='',
+                        help='Comma separated list of environment variable:value for server only')
+    parser.add_argument('--env-worker', type=str, default='',
+                        help='Comma separated list of environment variable:value for worker only')
     parser.add_argument('--yarn-app-classpath', type=str,
                         help=('Explicit YARN ApplicationMaster classpath.' +
                               'Can be used to override defaults.'))

--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -57,15 +57,23 @@ def get_memory_mb(mem_str):
 
 def parse_env_pairs(env_args):
     """
-    Convert a comma separated list of key:value to a dictionary
-    Example: `key1:value1,key2:value2` into a dictionary with 2 keys (key1 and key2)
+    Convert a list of key:value to a dictionary
+    Example: `['key1:value1', 'key2:value2']` into a dictionary with 2 keys ('key1' and 'key2')
     :param env_args:
     :return:
     """
+    def raise_unknown_format(pair):
+        raise ValueError("Couldn't recognize "+ pair +
+                         ". Expected is env_variable:value")
+
     envs = {}
-    for pair in env_args.split(","):
-        for k,v in pair.split(":"):
+    for pair in env_args:
+        try:
+            k,v = pair.split(":")
             envs[k] = v
+        except ValueError:
+            # to raise an error that user can understand
+            raise_unknown_format(pair)
     return envs
 
 def get_opts(args=None):
@@ -135,6 +143,10 @@ def get_opts(args=None):
                               ' Only valid in yarn jobs.'))
     parser.add_argument('--env', action='append', default=[],
                         help='Client and ApplicationMaster environment variables.')
+    parser.add_argument('--env-server', action='append', default=[],
+                        help='Environment variable:value for server only')
+    parser.add_argument('--env-worker', action='append', default=[],
+                        help='Environment variable:value for worker only')
     parser.add_argument('--yarn-app-classpath', type=str,
                         help=('Explicit YARN ApplicationMaster classpath.' +
                               'Can be used to override defaults.'))

--- a/tracker/dmlc_tracker/opts.py
+++ b/tracker/dmlc_tracker/opts.py
@@ -35,7 +35,6 @@ def get_cache_file_set(args):
             fset.add(fname)
     return fset, cmds
 
-
 def get_memory_mb(mem_str):
     """Get the memory in MB from memory string.
 
@@ -56,6 +55,18 @@ def get_memory_mb(mem_str):
         msg = 'Invalid memory specification %s, need to be a number follows g or m' % mem_str
         raise RuntimeError(msg)
 
+def parse_env_pairs(env_args):
+    """
+    Convert a comma separated list of key:value to a dictionary
+    Example: `key1:value1,key2:value2` into a dictionary with 2 keys (key1 and key2)
+    :param env_args:
+    :return:
+    """
+    envs = {}
+    for pair in env_args.split(","):
+        for k,v in pair.split(":"):
+            envs[k] = v
+    return envs
 
 def get_opts(args=None):
     """Get options to launch the job.
@@ -141,12 +152,14 @@ def get_opts(args=None):
                         directory into remote machines\'s SYNC_DST_DIR')
     parser.add_argument('command', nargs='+',
                         help='Command to be launched')
+
     parser.add_argument('--slurm-worker-nodes', default=None, type=int,
                         help=('Number of nodes on which workers are run. Used only in SLURM mode.' +
                               'If not explicitly set, it defaults to number of workers.'))
     parser.add_argument('--slurm-server-nodes', default=None, type=int,
                         help=('Number of nodes on which parameter servers are run. Used only in SLURM mode.' +
                               'If not explicitly set, it defaults to number of parameter servers.'))
+
     parser.add_argument('--kube-namespace', default="default", type=str,
                         help=('A namespace in whitch all tasks are run. Used only in Kubernetes mode.' +
                               'If not explicitly set, it defaults to default.'))

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -27,10 +27,10 @@ def prepare_envs(args):
     Load environment variables from arguments
     """
     envs = {}
-    # default env variables passed
-    envs['default'] = {'OMP_NUM_THREADS', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
+    # default env variables which are always passed by the system
+    envs['default'] = {'OMP_NUM_THREADS', 'KMP_AFFINITY', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
                           'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE'}
-    # given by user
+    # given by user with the option --env
     envs['user'] = set(args.env)
     # remove those specified by user from default so we can confirm that user has set these vars
     envs['default'].difference_update(envs['user'])
@@ -58,6 +58,7 @@ def get_envs_str(dmlc_envs, addnl_envs, is_server):
         v = os.getenv(k)
         if v is not None:
             append_env_var(envs, k, v)
+
     for k in addnl_envs['user']:
         v = os.getenv(k)
         if v is not None:

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -31,11 +31,11 @@ def prepare_envs(args):
     envs['default'] = set('OMP_NUM_THREADS', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
                           'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE')
     # given by user
-    envs['user'] = set(args.envs.split(","))
+    envs['user'] = set(args.env)
     # remove those specified by user from default so we can confirm that user has set these vars
     envs['default'].difference_update(envs['user'])
-    envs['server'] = parse_env_pairs(args.envs_server)
-    envs['worker'] = parse_env_pairs(args.envs_worker)
+    envs['server'] = parse_env_pairs(args.env_server)
+    envs['worker'] = parse_env_pairs(args.env_worker)
     return envs
 
 def get_envs_str(dmlc_envs, addnl_envs, is_server):

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -48,7 +48,7 @@ def get_envs_str(dmlc_envs, addnl_envs, is_server):
     """
     # appends a pair of key and value to the list representing export command
     def append_env_var(envs_list, key, value):
-        envs_list.append('export ' + k + '=' + v + ';')
+        envs_list.append('export ' + key + '=' + value + ';')
 
     # add role to dmlc_envs
     dmlc_envs['DMLC_ROLE'] = 'server' if is_server else 'worker'

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -30,8 +30,9 @@ def prepare_envs(args):
     # default env variables which are always passed by the system
     envs['default'] = {'OMP_NUM_THREADS', 'KMP_AFFINITY', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
                           'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE'}
+
     # given by user with the option --env
-    envs['user'] = set(args.env)
+    envs['user'] = set([item for item in args_env.split(',') if item])
     # remove those specified by user from default so we can confirm that user has set these vars
     envs['default'].difference_update(envs['user'])
     envs['server'] = parse_env_pairs(args.env_server)

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -20,7 +20,7 @@ def sync_dir(local_dir, slave_node, slave_dir):
     logging.info('rsync %s -> %s', local_dir, remote)
     prog = 'rsync -az --rsh="ssh -o StrictHostKeyChecking=no -p %s" %s %s' % (
         slave_node[1], local_dir, remote)
-    subprocess.check_call([prog], shell = True)
+    subprocess.check_call([prog], shell=True)
 
 def prepare_envs(args):
     """
@@ -32,7 +32,7 @@ def prepare_envs(args):
                           'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE'}
 
     # given by user with the option --env
-    envs['user'] = set([item for item in args_env.split(',') if item])
+    envs['user'] = set([item for item in args.env.split(',') if item])
     # remove those specified by user from default so we can confirm that user has set these vars
     envs['default'].difference_update(envs['user'])
     envs['server'] = parse_env_pairs(args.env_server)

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -28,8 +28,8 @@ def prepare_envs(args):
     """
     envs = {}
     # default env variables passed
-    envs['default'] = set('OMP_NUM_THREADS', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
-                          'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE')
+    envs['default'] = {'OMP_NUM_THREADS', 'LD_LIBRARY_PATH', 'AWS_ACCESS_KEY_ID',
+                          'AWS_SECRET_ACCESS_KEY', 'DMLC_INTERFACE'}
     # given by user
     envs['user'] = set(args.env)
     # remove those specified by user from default so we can confirm that user has set these vars
@@ -48,12 +48,12 @@ def get_envs_str(dmlc_envs, addnl_envs, is_server):
     """
     # appends a pair of key and value to the list representing export command
     def append_env_var(envs_list, key, value):
-        envs_list.append('export ' + key + '=' + value + ';')
+        envs_list.append('export ' + key + '=' + str(value) + ';')
 
     # add role to dmlc_envs
     dmlc_envs['DMLC_ROLE'] = 'server' if is_server else 'worker'
 
-    envs = ['export']
+    envs = []
     for k in addnl_envs['default']:
         v = os.getenv(k)
         if v is not None:
@@ -131,11 +131,9 @@ def submit(args):
             prog = get_envs_str(dmlc_envs, addnl_envs, is_server)
             prog += ' cd ' + working_dir + '; ' + (' '.join(args.command))
             prog = 'ssh -o StrictHostKeyChecking=no ' + node + ' -p ' + port + ' \'' + prog + '\''
-
-            thread = Thread(target = run, args=(prog,))
+            thread = Thread(target=run, args=(prog,))
             thread.setDaemon(True)
             thread.start()
-
         return ssh_submit
 
     tracker.submit(args.num_workers, args.num_servers,

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -337,14 +337,14 @@ class PSTracker(object):
     """
     Tracker module for PS
     """
-    def __init__(self, hostIP, cmd, port=9091, port_end=9999, envs=None):
+    def __init__(self, hostIP, cmd, port=9091, port_end=9999, dmlc_envs=None):
         """
         Starts the PS scheduler
         """
         self.cmd = cmd
         if cmd is None:
             return
-        envs = {} if envs is None else envs
+        dmlc_envs = {} if dmlc_envs is None else dmlc_envs
         self.hostIP = hostIP
         sock = socket.socket(get_family(hostIP), socket.SOCK_STREAM)
         for port in range(port, port_end):
@@ -356,11 +356,10 @@ class PSTracker(object):
             except socket.error:
                 continue
         env = os.environ.copy()
-
         env['DMLC_ROLE'] = 'scheduler'
         env['DMLC_PS_ROOT_URI'] = str(self.hostIP)
         env['DMLC_PS_ROOT_PORT'] = str(self.port)
-        for k, v in envs.items():
+        for k, v in dmlc_envs.items():
             env[k] = str(v)
         self.thread = Thread(
             target=(lambda: subprocess.check_call(self.cmd, env=env, shell=True)), args=())
@@ -406,26 +405,25 @@ def get_host_ip(hostIP=None):
             hostIP = s.getsockname()[0]
     return hostIP
 
-
-def submit(nworker, nserver, fun_submit, hostIP='auto', pscmd=None):
+def submit(nworker, nserver, fun_submit, hostIP='auto', pscmd=None, addnl_envs=None):
     if nserver == 0:
         pscmd = None
 
-    envs = {'DMLC_NUM_WORKER' : nworker,
+    dmlc_envs = {'DMLC_NUM_WORKER' : nworker,
             'DMLC_NUM_SERVER' : nserver}
     hostIP = get_host_ip(hostIP)
 
     if nserver == 0:
         rabit = RabitTracker(hostIP=hostIP, nslave=nworker)
-        envs.update(rabit.slave_envs())
+        dmlc_envs.update(rabit.slave_envs())
         rabit.start(nworker)
         if rabit.alive():
-           fun_submit(nworker, nserver, envs) 
+           fun_submit(nworker, nserver, dmlc_envs)
     else:
-        pserver = PSTracker(hostIP=hostIP, cmd=pscmd, envs=envs)
-        envs.update(pserver.slave_envs())
+        pserver = PSTracker(hostIP=hostIP, cmd=pscmd, dmlc_envs=dmlc_envs)
+        dmlc_envs.update(pserver.slave_envs())
         if pserver.alive():
-            fun_submit(nworker, nserver, envs)
+            fun_submit(nworker, nserver, dmlc_envs, addnl_envs)
 
     if nserver == 0:
         rabit.join()


### PR DESCRIPTION
Support to allow user to pass specific environment variables (server/worker/both) when using launch.py in MXNet

Example which can be supported now
```--env-server key:value,key2:value2 --env-worker key3:value3,key4:value4 --env key1,key2```

For local and ssh
