### PR TITLE
Make choice of archiver configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ $(OBJ) :
 	$(CXX) -c $(CFLAGS) -o $@ $(firstword $(filter %.cpp %.c %.cc, $^) )
 
 $(ALIB):
-	ar cr $@ $+
+	$(AR) cr $@ $+
 
 lint:
 	python scripts/lint.py dmlc ${LINT_LANG} include src scripts $(NOLINT_FILES)

--- a/make/config.mk
+++ b/make/config.mk
@@ -14,6 +14,9 @@ export CC = gcc
 export CXX = g++
 export MPICXX = mpicxx
 
+# choice of archiver
+export AR = ar
+
 # whether to compile with -fPIC option
 # Note: to build shared library(so files), fPIC is required
 WITH_FPIC = 1


### PR DESCRIPTION
At present, the build system assumes that the Unix archiv utility 'ar'
will always be present in PATH, but this might not be true if a separate
toolchain is being used. This patch makes the build system a bit more
cross-compile capable.