### PR TITLE
ListDirectory to warn rather than fatal-exit on dangling symlinks

### DIFF
--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -69,13 +69,22 @@ class FileStream : public SeekStream {
 
 FileInfo LocalFileSystem::GetPathInfo(const URI &path) {
   struct stat sb;
-  if (stat(path.name.c_str(), &sb) == -1) {
-    int errsv = errno;
-    LOG(FATAL) << "LocalFileSystem.GetPathInfo " << path.name
-               << " Error:" << strerror(errsv);
-  }
   FileInfo ret;
   ret.path = path;
+  if (stat(path.name.c_str(), &sb) == -1) {
+    int errsv = errno;
+    // If lstat succeeds where stat failed, assume a problematic
+    // symlink and treat this as if it were a 0-length file.
+    if (lstat(path.name.c_str(), &sb) == 0) {
+      ret.size = 0;
+      ret.type = kFile;
+      LOG(INFO) << "LocalFileSystem.GetPathInfo: detected symlink "
+                << path.name << " error: " << strerror(errsv);
+      return ret;
+    }
+    LOG(FATAL) << "LocalFileSystem.GetPathInfo: "
+               << path.name << " error: " << strerror(errsv);
+  }
   ret.size = sb.st_size;
 
   if ((sb.st_mode & S_IFMT) == S_IFDIR) {


### PR DESCRIPTION
A fix for issue #358.

ListDirectory expects to convert a directory to a vector of FileInfo. However, if the directory being listed contains a dangling symlink, the call fails with a fatal error 'no such file or directory'. Normally, one would expect this to be uncommon, however emacs creates dangling symlinks as part of its file locking strategy. Thus, a user emacs-editing a file (with a dirty buffer) would disrupt the proper operation of ListDirectory if run on the same directory.

The symlink issue is encountered in LocalFileSystem::GetPathInfo(), but that routine must return a FileInfo.  This fix thus has GetPathInfo map the fatal dangling symlink to a FileInfo depicting a 0-size file- such files are ignored by the current uses of ListDirectory().