### PR TITLE
Fix Windows compile errors

### DIFF
--- a/include/dmlc/thread_group.h
+++ b/include/dmlc/thread_group.h
@@ -127,7 +127,7 @@ class ThreadGroup {
         internal_join(true);
       }
       WriteLock guard(thread_mutex_);
-      if (thread_) {
+      if (thread_.load()) {
         std::thread *thrd = thread_;
         thread_ = nullptr;
         if (self_delete) {
@@ -211,7 +211,7 @@ class ThreadGroup {
      */
     bool joinable() const {
       ReadLock guard(thread_mutex_);
-      if (thread_) {
+      if (thread_.load()) {
         CHECK_EQ(auto_remove_, false);
         // be checked by searching the group or exit event.
         return thread_.load()->joinable();
@@ -245,7 +245,7 @@ class ThreadGroup {
       ReadLock guard(thread_mutex_);
       // should be careful calling (or any function externally) this when in
       // auto-remove mode
-      if (thread_ && thread_.load()->get_id() != std::thread::id()) {
+      if (thread_.load() && thread_.load()->get_id() != std::thread::id()) {
         std::thread::id someId;
         if (!auto_remove_ok) {
           CHECK_EQ(auto_remove_, false);


### PR DESCRIPTION
Windows compiler needs an explicit call to load() for an atomic in order to evaluate it as a boolean value