### PR TITLE
fix mpirun returns no version info

### DIFF
--- a/tracker/dmlc_tracker/mpi.py
+++ b/tracker/dmlc_tracker/mpi.py
@@ -21,7 +21,7 @@ def get_mpi_env(envs):
         return cmd
 
     # decide MPI version.
-    (_, err) = subprocess.Popen('mpirun',
+    (_, err) = subprocess.Popen(['mpirun','--verion'],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE).communicate()
     cmd = ''


### PR DESCRIPTION
Hi

The tracker/dmlc_tracker/mpi.py doesn't work for me (neither for openmpi v3 nor v1).
I found the problem is that it calls `mpirun` to check the version of the mpi implementation.
But it should has `-V` or `--version` to make the magic happen.

Could you merge the request to fix the problem?
Thanks