### PR TITLE
Better Exception Handling for Iterators

### DIFF
--- a/include/dmlc/threadediter.h
+++ b/include/dmlc/threadediter.h
@@ -352,7 +352,7 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
             consumer_cond_.notify_all();
             return;
           }
-        } // end of lock scope
+        }  // end of lock scope
         // now without lock
         produce_end_ = !next(&cell);
         DCHECK(cell != NULL || produce_end_);

--- a/make/config.mk
+++ b/make/config.mk
@@ -37,7 +37,7 @@ USE_AZURE = 0
 LIBJVM=$(JAVA_HOME)/jre/lib/amd64/server
 
 # whether building unittest (gtest is required)
-BUILD_TEST=0
+BUILD_TEST=1
 
 # path to gtest library (only used when $BUILD_TEST=1)
 # there should be an include path in $GTEST_PATH/include and library in $GTEST_PATH/lib

--- a/make/config.mk
+++ b/make/config.mk
@@ -37,7 +37,7 @@ USE_AZURE = 0
 LIBJVM=$(JAVA_HOME)/jre/lib/amd64/server
 
 # whether building unittest (gtest is required)
-BUILD_TEST=1
+BUILD_TEST=0
 
 # path to gtest library (only used when $BUILD_TEST=1)
 # there should be an include path in $GTEST_PATH/include and library in $GTEST_PATH/lib

--- a/test/unittest/unittest_threaditer_exc_handling.cc
+++ b/test/unittest/unittest_threaditer_exc_handling.cc
@@ -67,6 +67,7 @@ TEST(ThreadedIter, exception) {
     LOG(INFO) << "recycle exception caught";
   }
   CHECK(caught);
+  iter2.Init(&prod);
   caught = false;
   iter2.BeforeFirst();
   try {
@@ -89,6 +90,13 @@ TEST(ThreadedIter, exception) {
   } catch (dmlc::Error &e) {
     caught = true;
     LOG(INFO) << "beforefirst exception caught";
+  }
+  caught = false;
+  try {
+  iter3.BeforeFirst();
+  } catch (dmlc::Error &e) {
+    LOG(INFO) << "beforefirst exception thrown/caught";
+    caught = true;
   }
   CHECK(caught);
 }

--- a/test/unittest/unittest_threaditer_exc_handling.cc
+++ b/test/unittest/unittest_threaditer_exc_handling.cc
@@ -1,0 +1,74 @@
+#include <chrono>
+#include <dmlc/io.h>
+#include <dmlc/logging.h>
+#include <dmlc/threadediter.h>
+#include <gtest/gtest.h>
+
+using namespace dmlc;
+namespace producer_test {
+inline void delay(int sleep) {
+  if (sleep < 0) {
+    int d = rand() % (-sleep);
+    std::this_thread::sleep_for(std::chrono::milliseconds(d));
+  } else {
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
+  }
+}
+
+// int was only used as example, in real life
+// use big data blob
+struct IntProducerNextExc : public ThreadedIter<int>::Producer {
+  int counter;
+  int maxcap;
+  int sleep;
+  IntProducerNextExc(int maxcap, int sleep)
+      : counter(0), maxcap(maxcap), sleep(sleep) {}
+  virtual void BeforeFirst(void) { counter = 0; }
+  virtual bool Next(int **inout_dptr) {
+    if (counter == maxcap)
+      return false;
+    if (counter == (maxcap - 1)) {
+      counter++;
+      LOG(FATAL) << "Test Throw exception";
+    }
+    // allocate space if not exist
+    if (*inout_dptr == NULL) {
+      *inout_dptr = new int();
+    }
+    delay(sleep);
+    **inout_dptr = counter++;
+    return true;
+  }
+};
+}
+
+TEST(ThreadedIter, exception) {
+  using namespace producer_test;
+  int *value;
+  ThreadedIter<int> iter2;
+  iter2.set_max_capacity(7);
+  IntProducerNextExc prod(5, 100);
+  bool caught = false;
+  iter2.Init(&prod);
+  iter2.BeforeFirst();
+  try {
+    delay(700);
+    iter2.Recycle(&value);
+  } catch (dmlc::Error &e) {
+    caught = true;
+    LOG(INFO) << "recycle exception caught";
+  }
+  CHECK(caught);
+  caught = false;
+  iter2.BeforeFirst();
+  try {
+    while (iter2.Next(&value)) {
+      iter2.Recycle(&value);
+    }
+  } catch (dmlc::Error &e) {
+    caught = true;
+    LOG(INFO) << "next exception caught";
+  }
+  CHECK(caught);
+  LOG(INFO) << "finish";
+}

--- a/test/unittest/unittest_threaditer_exc_handling.cc
+++ b/test/unittest/unittest_threaditer_exc_handling.cc
@@ -40,6 +40,14 @@ struct IntProducerNextExc : public ThreadedIter<int>::Producer {
     return true;
   }
 };
+
+struct IntProducerBeforeFirst : public ThreadedIter<int>::Producer {
+  IntProducerBeforeFirst() {}
+  virtual void BeforeFirst(void) {
+    LOG(FATAL) << "Throw exception in before first";
+  }
+  virtual bool Next(int **inout_dptr) { return true; }
+};
 }
 
 TEST(ThreadedIter, exception) {
@@ -71,4 +79,16 @@ TEST(ThreadedIter, exception) {
   }
   CHECK(caught);
   LOG(INFO) << "finish";
+  ThreadedIter<int> iter3;
+  iter3.set_max_capacity(1);
+  IntProducerBeforeFirst prod2;
+  iter3.Init(&prod2);
+  caught = false;
+  try {
+    iter3.BeforeFirst();
+  } catch (dmlc::Error &e) {
+    caught = true;
+    LOG(INFO) << "beforefirst exception caught";
+  }
+  CHECK(caught);
 }


### PR DESCRIPTION
# Description

* Adds exception handling support for iterators.
* Exceptions thrown in beforefirst, next of the producer in threadediter will be caught and rethrown.
* Once the exception is set, it will always be rethrown for all following calls of next and beforefirst of the consumer. Exception_ptr will be reset to nullptr on another call of Init. 
* In addition to this, I have also added exception handling inside omp threads in TextParser.
* This should improve the usability experience of MXNet, which heavily uses ThreadedIter and TextParser.

# Testing

* Tested for scenarios where exception is thrown from producer's beforefirst and next and rethrown from next, beforefirst, recycle.
* Tested consecutive calls of beforefirst to make sure exception_ptr not cleared.
* Tested Init call after exception to test if its cleared.
* Will add additional tests to MXNet for TextParser.

@piiswrong @KellenSunderland @reminisce @madjam