### PR TITLE
Handle Windows killing all non-main threads on ExitProcess() called

### DIFF
--- a/test/unittest/unittest_thread_group.cc
+++ b/test/unittest/unittest_thread_group.cc
@@ -128,7 +128,7 @@ TEST(ThreadGroup, ThreadLaunchQueueThread) {
                    return 0;  // return 0 means continue
                  });
   // Trigger the queues to exit
-  thread_group->request_shutdown_all();
+  thread_group->request_shutdown_all(false);
   // Wait for all of the queue threads to exit
   thread_group->join_all();
   // Check that the queue is empty
@@ -178,7 +178,7 @@ TEST(ThreadGroup, TimerThread) {
     });
   std::this_thread::sleep_for(Duration(SLEEP_DURATION));
   // Trigger the queues to exit
-  thread_group->request_shutdown_all();
+  thread_group->request_shutdown_all(true);
   // Wait for all of the queue threads to exit
   thread_group->join_all();
   GTEST_ASSERT_GE(count, MIN_COUNT_WHILE_SLEEPING);  // Should have at least done three


### PR DESCRIPTION
Auto-remove threads are problematic on Windows during shutdown because Windows kills all threads immediately when ExsitProcess() is called, so the threads can;t auto-remove themselves.
Solution is to allow the threads to be set to non-auto-remove so that they can be joined during cleanup (they're already dead, so the join is trivial).