### PR TITLE
Pass DMLC_NODE_HOST env to worker or server in ssh launcher

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -72,6 +72,7 @@ def submit(args):
         for i in range(nworker + nserver):
             pass_envs['DMLC_ROLE'] = 'server' if i < nserver else 'worker'
             (node, port) = hosts[i % len(hosts)]
+            pass_envs['DMLC_NODE_HOST'] = node
             prog = get_env(pass_envs) + ' cd ' + working_dir + '; ' + (' '.join(args.command))
             prog = 'ssh -o StrictHostKeyChecking=no ' + node + ' -p ' + port + ' \'' + prog + '\''
             thread = Thread(target = run, args=(prog,))


### PR DESCRIPTION
To solve issue #364:
We hope pass correct DMLC_NODE_HOST to ps-lite. In default, this env is *not* passed and the ip of default interface is used.