### PR TITLE
Add nostream json parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ NOLINT_FILES = --exclude_path include/dmlc/concurrentqueue.h include/dmlc/blocki
 # this is the common build script for dmlc lib
 export LDFLAGS= -pthread -lm
 export CFLAGS = -O3 -Wall -Wno-unknown-pragmas -Iinclude  -std=c++0x
-LDFLAGS+= $(DMLC_LDFLAGS)
-CFLAGS+= $(DMLC_CFLAGS)
+LDFLAGS+= $(DMLC_LDFLAGS) $(ADD_LDFLAGS)
+CFLAGS+= $(DMLC_CFLAGS) $(ADD_CFLAGS)
 
 ifndef USE_SSE
 	USE_SSE = 1

--- a/make/config.mk
+++ b/make/config.mk
@@ -17,6 +17,12 @@ export MPICXX = mpicxx
 # choice of archiver
 export AR = ar
 
+# the additional link flags you want to add
+ADD_LDFLAGS =
+
+# the additional compile flags you want to add
+ADD_CFLAGS =
+
 # whether to compile with -fPIC option
 # Note: to build shared library(so files), fPIC is required
 WITH_FPIC = 1

--- a/test/unittest/unittest_any.cc
+++ b/test/unittest/unittest_any.cc
@@ -47,16 +47,26 @@ TEST(Any, json) {
   x["vec"] = std::vector<int>{1, 2, 3};
   x["int"] = 300;
 
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::ostringstream os;
+#else
+  std::string os;
+#endif
   {
     std::unordered_map<std::string, dmlc::any> temp(x);
     dmlc::JSONWriter writer(&os);
     writer.Write(temp);
     temp.clear();
   }
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::string json = os.str();
-  LOG(INFO) << json;
   std::istringstream is(json);
+#else
+  std::string json = os;
+  std::string is(json);
+#endif
+  LOG(INFO) << json;
+
   dmlc::JSONReader reader(&is);
   std::unordered_map<std::string, dmlc::any> copy_data;
   reader.Read(&copy_data);

--- a/test/unittest/unittest_json.cc
+++ b/test/unittest/unittest_json.cc
@@ -12,16 +12,25 @@ using namespace std;
 namespace json {
 template<typename T>
 inline void TestSaveLoad(T data) {
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::ostringstream os;
+#else
+  std::string os;
+#endif
   {
     T temp(data);
     dmlc::JSONWriter writer(&os);
     writer.Write(temp);
     temp.clear();
   }
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::string json = os.str();
-  LOG(INFO) << json;
   std::istringstream is(json);
+#else
+  std::string json = os;
+  std::string is(json);
+#endif
+  LOG(INFO) << json;
   dmlc::JSONReader reader(&is);
   T copy_data;
   reader.Read(&copy_data);
@@ -93,16 +102,25 @@ TEST(JSON, basics) {
 TEST(JSON, any) {
   dmlc::any x = std::vector<std::string>{"a", "b", "c"};
 
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::ostringstream os;
+#else
+  std::string os;
+#endif
   {
     dmlc::any temp(x);
     dmlc::JSONWriter writer(&os);
     writer.Write(temp);
   }
 
+#ifndef _LIBCPP_SGX_NO_IOSTREAMS
   std::string json = os.str();
-  LOG(INFO) << json;
   std::istringstream is(json);
+#else
+  std::string json = os;
+  std::string is(json);
+#endif
+  LOG(INFO) << json;
   dmlc::JSONReader reader(&is);
   dmlc::any copy_data;
   reader.Read(&copy_data);


### PR DESCRIPTION
Requires upstreaming changes to resolve https://github.com/intel/linux-sgx/issues/218.

This PR adds a no-stream implementation of the JSON parser to allow use of the TVM graph runtime in SGX.

The code passes the tests used for the original parser. One question is whether the quite-similar files should be merged using conditional compilation at the expense of clarity.