### PR TITLE
fix undefind std::unique_ptr

### DIFF
--- a/include/dmlc/input_split_shuffle.h
+++ b/include/dmlc/input_split_shuffle.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <string>
 #include <algorithm>
+#include <memory>
 
 namespace dmlc {
 /*! \brief class to construct input split with global shuffling */


### PR DESCRIPTION
if not add header file, then will error at this line ```std::unique_ptr<InputSplit> source_;``` during make.