### PR TITLE
AWS Signature version 4 (SIG4) Support for S3 Read and Write

### DIFF
--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -2,10 +2,7 @@
 extern "C" {
 #include <errno.h>
 #include <curl/curl.h>
-#include <curl/curl.h>
 #include <openssl/hmac.h>
-#include <openssl/md5.h>
-#include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/sha.h>
 }
@@ -73,7 +70,7 @@ struct XMLIter {
  * \param size size of hash
  * \return string in hex representation
  */
-static const std::string SHA256HashToHex(unsigned char *hash, int size) {
+static std::string SHA256HashToHex(unsigned char *hash, int size) {
   CHECK_EQ(size, SHA256_DIGEST_LENGTH);
   std::stringstream ss;
   for (int i=0; i < SHA256_DIGEST_LENGTH; i++) {
@@ -87,7 +84,7 @@ static const std::string SHA256HashToHex(unsigned char *hash, int size) {
  * \param str input to hash
  * \return string with hex representation of SHA256 Hash
  */
-static const std::string SHA256Hex(const std::string &str) noexcept {
+static std::string SHA256Hex(const std::string &str) noexcept {
   if (str.empty()) return "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
   unsigned char hash[SHA256_DIGEST_LENGTH];
   SHA256_CTX sha256;
@@ -103,7 +100,7 @@ static const std::string SHA256Hex(const std::string &str) noexcept {
  * \param time
  * \return datetime in above format as string
  */
-static const std::string GetDateISO8601(const std::time_t &t) noexcept {
+static std::string GetDateISO8601(const std::time_t &t) noexcept {
   char buf[sizeof "YYYYMMDDTHHMMSSZ"];
   std::strftime(buf, sizeof buf, "%Y%m%dT%H%M%SZ", std::gmtime(&t));
   return std::string{buf};
@@ -115,7 +112,7 @@ static const std::string GetDateISO8601(const std::time_t &t) noexcept {
  * \param time
  * \return datetime in above format as string
  */
-static const std::string GetDateYYYYMMDD(const std::time_t &t) noexcept {
+static std::string GetDateYYYYMMDD(const std::time_t &t) noexcept {
   char buf[sizeof "YYYYMMDD"];
   std::strftime(buf, sizeof buf, "%Y%m%d", std::gmtime(&t));
   return std::string{buf};
@@ -218,7 +215,7 @@ static std::string GetQueryMultipart(const std::map<std::string, std::string> &p
  * \param region s3 region
  * \return credential scope
  */
-static const std::string GetCredentialScope(const time_t &time, const std::string &region) {
+static std::string GetCredentialScope(const time_t &time, const std::string &region) {
   return GetDateYYYYMMDD(time) + "/" + region  + "/s3/aws4_request";
 }
 
@@ -231,11 +228,11 @@ static const std::string GetCredentialScope(const time_t &time, const std::strin
  * \param string_to_sign
  * \return signature
  */
-static const std::string CalculateSig4Sign(const std::time_t &request_date,
-                                           const std::string &secret,
-                                           const std::string &region,
-                                           const std::string &service,
-                                           const std::string &string_to_sign) {
+static std::string CalculateSig4Sign(const std::time_t &request_date,
+                                     const std::string &secret,
+                                     const std::string &region,
+                                     const std::string &service,
+                                     const std::string &string_to_sign) {
   const std::string key1{"AWS4" + secret};
   const std::string yyyymmdd = GetDateYYYYMMDD(request_date);
 
@@ -884,7 +881,7 @@ void WriteStream::Run(const std::string &method,
   AddDefaultCanonicalHeaders(&canonical_headers, curr_time, s3_session_token_, data, true);
   std::string canonical_query = GetQueryMultipart(params, true);
   std::string canonical_uri;
-  std::ostringstream sauth, sdate, stoken, surl, scontent, smd5;
+  std::ostringstream sauth, sdate, stoken, surl, scontent;
   std::ostringstream rheader, rdata;
   if (path_.host.find('.', 0) == std::string::npos) {
     canonical_uri = URIEncode(path_.name, false);

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -341,27 +341,29 @@ static std::string SignSig4(const std::string &key,
                             const std::string &canonical_query,
                             const std::map<std::string, std::string> &canonical_headers,
                             const std::string &payload) {
-  std::ostringstream stream;
-  stream << method << "\n";
-  stream << canonical_uri << "\n";
-  stream << canonical_query << "\n";
+  std::ostringstream can_req;
+  can_req << method << "\n";
+  can_req << canonical_uri << "\n";
+  can_req << canonical_query << "\n";
   for (const auto & header : canonical_headers) {
-    stream << header.first << ":"<<header.second << "\n";
+    can_req << header.first << ":"<<header.second << "\n";
   }
-    stream << "\n";
-    stream << GetSignedHeaders(canonical_headers);
-    stream << "\n";
-  stream << SHA256Hex(payload);
-  std::string canonical_request = stream.str();
+  can_req << "\n";
+  can_req << GetSignedHeaders(canonical_headers);
+  can_req << "\n";
+  can_req << SHA256Hex(payload);
+
+  std::string canonical_request = can_req.str();
   std::string hash_request = SHA256Hex(canonical_request);
+
   std::ostringstream to_sign;
   to_sign << "AWS4-HMAC-SHA256" << "\n";
   to_sign << GetDateISO8601(time) << "\n";
-  // credential scope
   to_sign << GetCredentialScope(time, s3_region) << "\n";
   to_sign << hash_request;
   return CalculateSig4Sign(time, key, s3_region, "s3", to_sign.str());
 }
+
 static std::string ComputeMD5(const std::string &buf) {
   if (buf.length() == 0) return "";
   unsigned char md[MD5_DIGEST_LENGTH];
@@ -397,7 +399,7 @@ inline bool FindHttpError(const std::string &header) {
  * \return datetime string as string
  */
 inline std::string GetDateTimeString(void) {
-  time_t t = time(nullptr);
+  time_t t = time(NULL);
   tm gmt;
   gmtime_r(&t, &gmt);
   char buf[256];
@@ -436,7 +438,7 @@ std::string getEndpoint(std::string region_name) {
 }
 
 /*!
- * Encodeing as required by SIG4
+ * Encoding as required by SIG4
  * \param str string to encode
  * \param reserved string which contains characters that should not be encoded
  * \param encodeSlash whether or not to encode slash (/) character

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -165,20 +165,20 @@ static const std::string utc_yyyymmdd(const std::time_t& t) noexcept {
   return std::string{buf};
 }
 
-static std::string HexSHA256Hash(const std::string &str) {
+//static std::string HexSHA256Hash(const std::string &str) {
 //  std::cout<<"string to hash with hexsha256" << str<<" ; and hash is ";
-  unsigned char hash[SHA256_DIGEST_LENGTH];
-  SHA256_CTX sha256;
-  SHA256_Init(&sha256);
-  SHA256_Update(&sha256, str.c_str(), str.size());
-  SHA256_Final(hash, &sha256);
-  std::stringstream ss;
-  for(int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-  {
-    ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
-  }
-  return ss.str();
-}
+//  unsigned char hash[SHA256_DIGEST_LENGTH];
+//  SHA256_CTX sha256;
+//  SHA256_Init(&sha256);
+//  SHA256_Update(&sha256, str.c_str(), str.size());
+//  SHA256_Final(hash, &sha256);
+//  std::stringstream ss;
+//  for(int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+//  {
+//    ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+//  }
+//  return ss.str();
+//}
 
 void HMAC_Hash(const std::string &key, const std::string &msg, unsigned char* hash, int hash_length) {
   CHECK_EQ(hash_length, 32);
@@ -197,16 +197,18 @@ void HMAC_Hash(const std::string &key, const std::string &msg, unsigned char* ha
  * @param msg payload
  * @return
  */
-static std::string HMAC_String(const std::string &key, const std::string& msg) {
-  unsigned char hash[32];
-  HMAC_Hash(key, msg, hash, 32);
-  std::cout<<"key:"<<key<<"\nmsg:"<<msg<<std::endl;
-  std::stringstream ss;
-  ss << std::setfill('0');
-  for (int i = 0; i < 32; i++) {
-    ss  << hash[i];
-  }
-  return ss.str();
+static std::vector<uint8_t> HMAC_SHA256(const std::vector<uint8_t>& key,const std::vector<uint8_t>& value) {
+  unsigned int len = SHA256_DIGEST_LENGTH;
+  unsigned char hash[SHA256_DIGEST_LENGTH];
+  size_t keyLen = key.size();
+  size_t valueLen = value.size();
+  HMAC_CTX hmac;
+  HMAC_CTX_init(&hmac);
+  HMAC_Init_ex(&hmac, (unsigned char*)key.data(), keyLen, EVP_sha256(), NULL);
+  HMAC_Update(&hmac, (unsigned char*)value.data(), valueLen);
+  HMAC_Final(&hmac, hash, &len);
+  HMAC_CTX_cleanup(&hmac);
+  return std::vector<uint8_t>((uint8_t*)hash,(uint8_t*)hash+SHA256_DIGEST_LENGTH);
 }
 
 
@@ -216,18 +218,22 @@ static std::string HMAC_String(const std::string &key, const std::string& msg) {
 * @param msg payload
 * @return
 */
-static std::string HMAC_Hex(const std::string &key, const std::string& msg) {
-    unsigned char hash[32];
-    HMAC_Hash(key, msg, hash, 32);
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (int i = 0; i < 32; i++) {
-      ss << std::hex << std::setw(2)  << (unsigned int)hash[i];
-    }
-    std::cout<<ss.str()<<std::endl;
-    return ss.str();
-}
+static std::string HMAC_SHA256_Hex(const std::vector<uint8_t>& key, const std::vector<uint8_t>& value) {
 
+  std::vector<uint8_t> hash_string = HMAC_SHA256(key, value);
+  unsigned char* test = new unsigned char[hash_string.size()];//init this with the correct size
+  std::copy(hash_string.begin(), hash_string.end(), test);
+  std::string s = Base64(test, hash_string.size());
+  delete[] test;
+  std::stringstream ss;
+  ss << std::hex << std::setfill('0');
+  for (int i = 0; i < hash_string.size(); i++) {
+    ss << std::hex << std::setw(2)  << hash_string[i];
+  }
+  std::cout<< ss.str()<<std::endl;
+  std::cout<< s <<std::endl;
+  return s;
+}
 
 static std::string GetSignedHeaders(const std::map<std::string, std::string> &canonical_headers) {
   std::ostringstream stream;
@@ -249,52 +255,26 @@ const std::string calculate_signature(const std::time_t& request_date,
                                       const std::string secret,
                                       const std::string region,
                                       const std::string service,
-                                      std::string string_to_sign) noexcept {
-  const std::string k1{"AWS4" + secret};
-  char *c_k1 = new char [k1.length()+1];
-  std::strcpy(c_k1, k1.c_str());
+                                      const std::string string_to_sign) noexcept {
+  std::string full_secret{"AWS4" + secret};
+  std::vector<uint8_t> k_secret(full_secret.begin(), full_secret.end());
 
-  auto yyyymmdd = utc_yyyymmdd(request_date);
-  char *c_yyyymmdd = new char [yyyymmdd.length()+1];
-  std::strcpy(c_yyyymmdd, yyyymmdd.c_str());
+  const std::string datestamp = utc_yyyymmdd(request_date);
+  std::vector<uint8_t> datestamp_v(datestamp.begin(), datestamp.end());
+  std::vector<uint8_t> k_date = HMAC_SHA256(k_secret, datestamp_v);
 
-  unsigned char* kDate;
-  kDate = HMAC(EVP_sha256(), c_k1, strlen(c_k1),
-               (unsigned char*)c_yyyymmdd, strlen(c_yyyymmdd), NULL, NULL);
+  std::vector<uint8_t> region_v(region.begin(), region.end());
+  std::vector<uint8_t> k_region = HMAC_SHA256(k_date, region_v);
 
-  char *c_region = new char [region.length()+1];
-  std::strcpy(c_region, region.c_str());
-  unsigned char *kRegion;
-  kRegion = HMAC(EVP_sha256(), kDate, strlen((char *)kDate),
-                 (unsigned char*)c_region, strlen(c_region), NULL, NULL);
+  std::vector<uint8_t> service_v(service.begin(), service.end());
+  std::vector<uint8_t> k_service = HMAC_SHA256(k_date, service_v);
 
-  char *c_service = new char [service.length()+1];
-  std::strcpy(c_service, service.c_str());
-  unsigned char *kService;
-  kService = HMAC(EVP_sha256(), kRegion, strlen((char *)kRegion),
-                  (unsigned char*)c_service, strlen(c_service), NULL, NULL);
+  const std::string aws4_request = "aws4_request";
+  std::vector<uint8_t> aws4_request_v(aws4_request.begin(), aws4_request.end());
+  std::vector<uint8_t> k_signing = HMAC_SHA256(k_service, aws4_request_v);
 
-  std::string aws4_request = "aws4_request";
-  char *c_aws4_request = new char [aws4_request.length()+1];
-  std::strcpy(c_aws4_request, aws4_request.c_str());
-  unsigned char *kSigning;
-  kSigning = HMAC(EVP_sha256(), kService, strlen((char *)kService),
-                  (unsigned char*)c_aws4_request, strlen(c_aws4_request), NULL, NULL);
-
-  char *c_string_to_sign = new char [string_to_sign.length()+1];
-  std::strcpy(c_string_to_sign, string_to_sign.c_str());
-  unsigned char *kSig;
-  kSig = HMAC(EVP_sha256(), kSigning, strlen((char *)kSigning),
-              (unsigned char*)c_string_to_sign, strlen(c_string_to_sign), NULL, NULL);
-
-  LOG(INFO) <<"ksigning:"<<kSigning<<std::endl;
-  char outputBuffer[65];
-  for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    sprintf(outputBuffer + (i * 2), "%02x", kSig[i]);
-  }
-  outputBuffer[64] = 0;
-  LOG(INFO) << "signature: "<<std::string{outputBuffer};
-  return std::string{outputBuffer};
+  std::vector<uint8_t> to_sign_v(string_to_sign.begin(), string_to_sign.end());
+  return HMAC_SHA256_Hex(k_signing, to_sign_v);
 }
 
 // sign S3 key
@@ -311,15 +291,15 @@ static std::string SignSig4(const std::string &key,
   stream << canonical_uri << "\n";
   stream << canonical_query << "\n";
   for (const auto & header : canonical_headers) {
-    stream << header.first << ": "<<header.second << "\n";
+    stream << header.first << ":"<<header.second << "\n";
   }
     stream << "\n";
     stream << GetSignedHeaders(canonical_headers);
     stream << "\n";
   stream << sha256_base16(payload);
   std::string canonical_request = stream.str();
-  std::cout<<canonical_request<<std::endl;
-  LOG(INFO) << "Above was canonical request";
+  LOG(INFO) << canonical_request;
+
   std::string hash_request = sha256_base16(canonical_request);
   std::ostringstream to_sign;
   to_sign << "AWS4-HMAC-SHA256" << "\n";
@@ -328,6 +308,7 @@ static std::string SignSig4(const std::string &key,
   to_sign << GetCredentialScope(time, s3_region) << "\n";
   to_sign << hash_request;
 
+  LOG(INFO) << to_sign.str();
   return calculate_signature(time, key, s3_region, "s3", to_sign.str());
 }
 
@@ -366,7 +347,7 @@ inline bool FindHttpError(const std::string &header) {
  * \return datestring
  */
 inline std::string GetDateString(void) {
-  time_t t = time(NULL);
+  time_t t = time(nullptr);
   tm gmt;
   gmtime_r(&t, &gmt);
   char buf[256];
@@ -1015,6 +996,13 @@ void WriteStream::Finish(void) {
   Run("POST", path_, sarg.str(),
       "text/xml", sdata.str(), &rheader, &rdata);
 }
+//
+//std::string url_encode(const std::string& str) {
+//  std::stringstream esc;
+//  esc.fill('0');
+//  esc << std::hex << std::
+//}
+
 /*!
  * \brief list the objects in the bucket with prefix specified by path.name
  * \param path the path to query
@@ -1033,13 +1021,13 @@ void ListObjects(const URI &path,
   CHECK(path.host.length() != 0) << "bucket name not specified in s3";
   out_list->clear();
   // TODO CHECK IF / is required at the start
-  std::string canonical_uri = path.host + path.name;
+  std::string canonical_uri = "/";path.host + path.name;
   std::string canonical_querystring = "";//"?delimiter=/&prefix=";
   std::map<std::string, std::string> canonical_headers;
   time_t curr_time = time(NULL);
   canonical_headers["x-amz-date"] = ISO8601_date(curr_time);
-  canonical_headers["host"] = "s3.amazonaws.com";
-  canonical_headers["x-amz-content-sha256"] = HexSHA256Hash("");
+  canonical_headers["host"] = path.host + ".s3.amazonaws.com";
+//  canonical_headers["x-amz-content-sha256"] = HexSHA256Hash("");
   if (s3_session_token != "") {
     canonical_headers["x-amz-security-token"] = s3_session_token;
   }
@@ -1049,7 +1037,6 @@ void ListObjects(const URI &path,
                                    canonical_querystring,
                                    canonical_headers,
                                    "");
-
   std::ostringstream sauth, sdate, stoken, surl, scontent;
   std::ostringstream result;
   sauth << "Authorization: AWS4-HMAC-SHA256 ";
@@ -1062,8 +1049,8 @@ void ListObjects(const URI &path,
 
   if (path.host.find('.', 0) == std::string::npos && s3_region == "us-east-1") {
   //     for backword compatibility, use virtual host if no period in host and no region was set.
-    surl << "https://" << path.host << ".s3.amazonaws.com"
-         << "/?delimiter=/&prefix=" << RemoveBeginSlash(path.name);
+    surl << "https://" << path.host << ".s3.amazonaws.com";
+//         << "/?delimiter=/&prefix=" << RemoveBeginSlash(path.name);
   } else {
     LOG(FATAL) << "Failed";
     surl << "https://" << s3_endpoint << "/" << path.host << path.name;

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1132,6 +1132,7 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
          << "/?delimiter=/&prefix=" << RemoveBeginSlash(path.name);
   } else {
     std::string canonical_uri = "/" + path.host + "/";
+    canonical_uri = URIEncode(canonical_uri, false);
     canonical_headers["host"] = s3_endpoint_;
     std::string signature = SignSig4(s3_secret_key_, s3_region_, "GET", curr_time,
                                      canonical_uri, canonical_querystring,

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -165,7 +165,7 @@ static const std::string SHA256Hex(const std::string &str) noexcept {
   SHA256(str, hashOut);
   char outputBuffer[65];
   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    snprintf(outputBuffer + (i * 2), 2, "%02x", hashOut[i]);
+    snprintf(outputBuffer + (i * 2), 65, "%02x", hashOut[i]);
   }
   outputBuffer[64] = 0;
   return std::string{outputBuffer};
@@ -242,7 +242,7 @@ static const std::string CalculateSig4Sign(const std::time_t &request_date,
 
   auto yyyymmdd = GetDateYYYYMMDD(request_date);
   char *c_yyyymmdd = new char[yyyymmdd.length() + 1];
-  std::snprintf(c_yyyymmdd, yyyymmdd.length() + 1, yyyymmdd.c_str());
+  std::snprintf(c_yyyymmdd, yyyymmdd.length() + 1, "%s", yyyymmdd.c_str());
 
   unsigned char* kDate;
   unsigned int kDateLen;
@@ -272,7 +272,7 @@ static const std::string CalculateSig4Sign(const std::time_t &request_date,
                   (unsigned char*)c_aws4_request, strlen(c_aws4_request), NULL, &kSigningLen);
 
   char *c_string_to_sign = new char[string_to_sign.length() + 1];
-  std::snprintf(c_string_to_sign, string_to_sign.length() + 1, string_to_sign.c_str());
+  std::snprintf(c_string_to_sign, string_to_sign.length() + 1, "%s", string_to_sign.c_str());
   unsigned char *kSig;
   unsigned int kSigLen;
   kSig = HMAC(EVP_sha256(), kSigning, strlen(reinterpret_cast<char *>(kSigning)),
@@ -280,7 +280,7 @@ static const std::string CalculateSig4Sign(const std::time_t &request_date,
   // convert to hex
   char outputBuffer[65];
   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    snprintf(outputBuffer + (i * 2), 2, "%02x", kSig[i]);
+    snprintf(outputBuffer + (i * 2), 65, "%02x", kSig[i]);
   }
   outputBuffer[64] = 0;
   return std::string{outputBuffer};

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -947,7 +947,6 @@ class WriteStream : public Stream {
 };
 
 void WriteStream::Write(const void *ptr, size_t size) {
-  std::cout<<size<<std::endl;
   size_t rlen = buffer_.length();
   buffer_.resize(rlen + size);
   std::memcpy(BeginPtr(buffer_) + rlen, ptr, size);
@@ -1105,13 +1104,6 @@ void WriteStream::Finish(void) {
 }
 }  // namespace s3
 
-/*!
-* \brief list the objects in the bucket with prefix specified by path.name
-* \param path the path to query
-* \param s3_id access id of s3
-* \param s3_key access key of s3
-* \paam out_list stores the output results
-*/
 void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list) {
   CHECK(path.host.length() != 0) << "bucket name not specified in s3";
   out_list->clear();
@@ -1129,7 +1121,7 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
   std::ostringstream sauth, sdate, stoken, surl, scontent;
   std::ostringstream result;
 
-  if (false && path.host.find('.', 0) == std::string::npos) {
+  if (path.host.find('.', 0) == std::string::npos) {
     // use virtual host style if no period in host
     std::string canonical_uri = "/";
     canonical_headers["host"] = path.host + ".s3.amazonaws.com";
@@ -1142,7 +1134,6 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
     surl << "https://" << path.host << ".s3.amazonaws.com"
          << "/?delimiter=/&prefix=" << RemoveBeginSlash(path.name);
   } else {
-    LOG(INFO) << "Using this style";
     std::string canonical_uri = "/" + path.host + "/";
     canonical_headers["host"] = s3_endpoint_;
     std::string signature = SignSig4(s3_secret_key_, s3_region_, "GET", curr_time,
@@ -1151,8 +1142,8 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
     BuildRequestHeaders(sauth, sdate, stoken, scontent,
                         curr_time, s3_access_id_, s3_region_, s3_session_token_,
                         canonical_headers, signature, payload);
-    surl << "https://" << s3_endpoint_ << "/" << path.host << "/?delimiter=/&prefix=" << RemoveBeginSlash(path.name);
-    LOG(INFO) << surl.str();
+    surl << "https://" << s3_endpoint_ << "/" << path.host << "/?delimiter=/&prefix="
+         << RemoveBeginSlash(path.name);
   }
 
 // make request
@@ -1193,7 +1184,6 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
       info.path = path;
       XMLIter value;
       CHECK(data.GetNext("Key", &value));
-      std::cout<< " * " << value.str()<<std::endl;
       // add root path to be consistent with other filesys convention
       info.path.name = '/' + value.str();
       CHECK(data.GetNext("Size", &value));
@@ -1212,7 +1202,6 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
       XMLIter value;
       CHECK(data.GetNext("Prefix", &value));
       // add root path to be consistent with other filesys convention
-      std::cout<<value.str()<<std::endl;
       info.path.name = '/' + value.str();
       info.size = 0; info.type = kDirectory;
       out_list->push_back(info);

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1036,8 +1036,7 @@ void WriteStream::Run(const std::string &method,
     CHECK(curl_easy_setopt(ecurl_, CURLOPT_WRITEHEADER, WriteSStreamCallback) == CURLE_OK);
     CHECK(curl_easy_setopt(ecurl_, CURLOPT_HEADERDATA, &rheader) == CURLE_OK);
     CHECK(curl_easy_setopt(ecurl_, CURLOPT_NOSIGNAL, 1) == CURLE_OK);
-    CHECK(curl_easy_setopt(ecurl_, CURLOPT_VERBOSE, 1) == CURLE_OK);
-    if (!s3_verify_ssl_ == "0") {
+    if (!s3_verify_ssl_) {
       CHECK(curl_easy_setopt(ecurl_, CURLOPT_SSL_VERIFYHOST, 0L) == CURLE_OK);
       CHECK(curl_easy_setopt(ecurl_, CURLOPT_SSL_VERIFYPEER, 0L) == CURLE_OK);
     }

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1222,7 +1222,7 @@ void S3FileSystem::ListDirectory(const URI &path, std::vector<FileInfo> *out_lis
     }
     if (files[i].path.name == pdir) {
       CHECK(files[i].type == kDirectory);
-      ListObjects(path, out_list);
+      ListObjects(files[i].path, out_list);
       return;
     }
   }

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1214,6 +1214,11 @@ void S3FileSystem::ListDirectory(const URI &path, std::vector<FileInfo> *out_lis
   std::string pdir = path.name + '/';
   out_list->clear();
   ListObjects(path,  &files);
+  if (path.name.empty()) {
+    // then insert all files in the bucket
+    out_list->insert(out_list->end(), files.begin(), files.end());
+    return;
+  }
   for (size_t i = 0; i < files.size(); ++i) {
     if (files[i].path.name == path.name) {
       CHECK(files[i].type == kFile);

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -165,7 +165,7 @@ static const std::string SHA256Hex(const std::string &str) noexcept {
   SHA256(str, hashOut);
   char outputBuffer[65];
   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    snprintf(outputBuffer + (i * 2), 65, "%02x", hashOut[i]);
+    snprintf(outputBuffer + (i * 2), sizeof(outputBuffer), "%02x", hashOut[i]);
   }
   outputBuffer[64] = 0;
   return std::string{outputBuffer};
@@ -276,11 +276,12 @@ static const std::string CalculateSig4Sign(const std::time_t &request_date,
   unsigned char *kSig;
   unsigned int kSigLen;
   kSig = HMAC(EVP_sha256(), kSigning, strlen(reinterpret_cast<char *>(kSigning)),
-              reinterpret_cast<unsigned char*>(c_string_to_sign), strlen(c_string_to_sign), NULL, &kSigLen);
+              reinterpret_cast<unsigned char*>(c_string_to_sign),
+              strlen(c_string_to_sign), NULL, &kSigLen);
   // convert to hex
   char outputBuffer[65];
   for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-    snprintf(outputBuffer + (i * 2), 65, "%02x", kSig[i]);
+    snprintf(outputBuffer + (i * 2), sizeof(outputBuffer), "%02x", kSig[i]);
   }
   outputBuffer[64] = 0;
   return std::string{outputBuffer};

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -266,7 +266,7 @@ static const std::string CalculateSig4Sign(const std::time_t &request_date,
 
   unsigned char *kSig;
   unsigned int kSigLen;
-  kSig = HMAC(EVP_sha256(), kSigning, strlen(reinterpret_cast<char *>(kSigning)),
+  kSig = HMAC(EVP_sha256(), kSigning, kSigningLen,
               reinterpret_cast<const unsigned char*>(string_to_sign.c_str()),
               string_to_sign.size(), NULL, &kSigLen);
   return SHA256HashToHex(kSig, SHA256_DIGEST_LENGTH);

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -871,6 +871,7 @@ class WriteStream : public Stream {
 };
 
 void WriteStream::Write(const void *ptr, size_t size) {
+  std::cout<<size<<std::endl;
   size_t rlen = buffer_.length();
   buffer_.resize(rlen + size);
   std::memcpy(BeginPtr(buffer_) + rlen, ptr, size);
@@ -1000,51 +1001,52 @@ void WriteStream::Run(const std::string &method,
 }
 
 void WriteStream::Init(void) {
-  std::string rheader, rdata;
-  Run("POST", path_, "?uploads",
-      "binary/octel-stream", "", &rheader, &rdata);
-  XMLIter xml(rdata.c_str());
-  XMLIter upid;
-  CHECK(xml.GetNext("UploadId", &upid)) << "missing UploadId";
-  upload_id_ = upid.str();
+//  std::string rheader, rdata;
+//  Run("POST", path_, "?uploads",
+//      "binary/octel-stream", "", &rheader, &rdata);
+//  XMLIter xml(rdata.c_str());
+//  XMLIter upid;
+//  CHECK(xml.GetNext("UploadId", &upid)) << "missing UploadId";
+//  upload_id_ = upid.str();
 }
 
 void WriteStream::Upload(bool force_upload_even_if_zero_bytes) {
   if (buffer_.length() == 0 && !force_upload_even_if_zero_bytes) return;
   std::ostringstream sarg;
   std::string rheader, rdata;
-  size_t partno = etags_.size() + 1;
+//  size_t partno = etags_.size() + 1;
 
-  sarg << "?partNumber=" << partno << "&uploadId=" << upload_id_;
-  Run("PUT", path_, sarg.str(),
-      "binary/octel-stream", buffer_, &rheader, &rdata);
-  const char *p = strstr(rheader.c_str(), "ETag: ");
-  CHECK(p != NULL) << "cannot find ETag in header";
-  p = strchr(p, '\"');
-  CHECK(p != NULL) << "cannot find ETag in header";
-  const char *end = strchr(p + 1, '\"');
-  CHECK(end != NULL) << "cannot find ETag in header";
-
-  etags_.push_back(std::string(p, end - p + 1));
-  part_ids_.push_back(partno);
+//  sarg << "?partNumber=" << partno << "&uploadId=" << upload_id_;
+//
+//  Run("PUT", path_, sarg.str(),
+//      "binary/octel-stream", buffer_, &rheader, &rdata);
+//  const char *p = strstr(rheader.c_str(), "ETag: ");
+//  CHECK(p != NULL) << "cannot find ETag in header";
+//  p = strchr(p, '\"');
+//  CHECK(p != NULL) << "cannot find ETag in header";
+//  const char *end = strchr(p + 1, '\"');
+//  CHECK(end != NULL) << "cannot find ETag in header";
+//
+//  etags_.push_back(std::string(p, end - p + 1));
+//  part_ids_.push_back(partno);
   buffer_.clear();
 }
 
 void WriteStream::Finish(void) {
-  std::ostringstream sarg, sdata;
-  std::string rheader, rdata;
-  sarg << "?uploadId=" << upload_id_;
-  sdata << "<CompleteMultipartUpload>\n";
-  CHECK(etags_.size() == part_ids_.size());
-  for (size_t i = 0; i < etags_.size(); ++i) {
-    sdata << " <Part>\n"
-          << "  <PartNumber>" << part_ids_[i] << "</PartNumber>\n"
-          << "  <ETag>" << etags_[i] << "</ETag>\n"
-          << " </Part>\n";
-  }
-  sdata << "</CompleteMultipartUpload>\n";
-  Run("POST", path_, sarg.str(),
-      "text/xml", sdata.str(), &rheader, &rdata);
+//  std::ostringstream sarg, sdata;
+//  std::string rheader, rdata;
+//  sarg << "?uploadId=" << upload_id_;
+//  sdata << "<CompleteMultipartUpload>\n";
+//  CHECK(etags_.size() == part_ids_.size());
+//  for (size_t i = 0; i < etags_.size(); ++i) {
+//    sdata << " <Part>\n"
+//          << "  <PartNumber>" << part_ids_[i] << "</PartNumber>\n"
+//          << "  <ETag>" << etags_[i] << "</ETag>\n"
+//          << " </Part>\n";
+//  }
+//  sdata << "</CompleteMultipartUpload>\n";
+//  Run("POST", path_, sarg.str(),
+//      "text/xml", sdata.str(), &rheader, &rdata);
 }
 }  // namespace s3
 

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -67,11 +67,16 @@ struct XMLIter {
   }
 };
 
+/*!
+ * \brief Converts hash to hex representation
+ * \param hash unsigned char array with hash
+ * \param size size of hash
+ * \return string in hex representation
+ */
 static const std::string SHA256HashToHex(unsigned char *hash, int size) {
   CHECK_EQ(size, SHA256_DIGEST_LENGTH);
   std::stringstream ss;
-  for(int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-  {
+  for(int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
     ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
   }
   return ss.str();
@@ -84,7 +89,6 @@ static const std::string SHA256HashToHex(unsigned char *hash, int size) {
  */
 static const std::string SHA256Hex(const std::string &str) noexcept {
   if (str.empty()) return "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-
   unsigned char hash[SHA256_DIGEST_LENGTH];
   SHA256_CTX sha256;
   SHA256_Init(&sha256);
@@ -182,7 +186,7 @@ std::string URIEncode(const std::string& str,
 }
 
 /*!
- * \brief encodes keys and values in params to return query string
+ * \brief creates query string from keys and values in params
  * \param params query keys and values
  * \param is_canonical whether or not to produce canonical query by URIEncoding
  * \return query as a string

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -89,6 +89,9 @@ class S3FileSystem : public FileSystem {
    * \return return false when path do not exist
    */
   bool TryGetPathInfo(const URI &path, FileInfo *info);
+
+  void ListObjects(const URI &path, std::vector<FileInfo> *out_list);
+
 };
 }  // namespace io
 }  // namespace dmlc

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -90,6 +90,11 @@ class S3FileSystem : public FileSystem {
    */
   bool TryGetPathInfo(const URI &path, FileInfo *info);
 
+  /*!
+  * \brief list the objects in the bucket with prefix specified by path.name
+  * \param path the path to query
+  * \param out_list stores the output results which match given prefix
+  */
   void ListObjects(const URI &path, std::vector<FileInfo> *out_list);
 
 };

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -96,7 +96,6 @@ class S3FileSystem : public FileSystem {
   * \param out_list stores the output results which match given prefix
   */
   void ListObjects(const URI &path, std::vector<FileInfo> *out_list);
-
 };
 }  // namespace io
 }  // namespace dmlc

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -80,7 +80,7 @@ class S3FileSystem : public FileSystem {
   /*! \brief S3 endpoint*/
   std::string s3_endpoint_;
   /*! \brief S3 verify ssl*/
-  std::string s3_verify_ssl_;
+  bool s3_verify_ssl_;
 
   /*!
    * \brief try to get information about a path


### PR DESCRIPTION
Updated S3 File system to support SIG4. Replaces SIG2 because that is only supported in us-east-1 currently and SIG4 is supported in all regions.

Updated the original PR to fix both reads and writes