### PR TITLE
Fix segfault when verify_ssl is null

### DIFF
--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -956,7 +956,9 @@ S3FileSystem::S3FileSystem() {
     s3_endpoint_ = endpoint;
   }
 
-  s3_verify_ssl_ = verify_ssl;
+  if (verify_ssl != NULL) {
+    s3_verify_ssl_ = verify_ssl;
+  }
 }
 
 void S3FileSystem::SetCredentials(const std::string& s3_access_id,


### PR DESCRIPTION
If the `S3_VERIFY_SSL` environment variable is not set, `verify_ssl` will be `NULL`. Currently this causes a segfault; let's let it default to the empty string instead.