### PR TITLE
Handle NOEOL files in partitioned text data files

### DIFF
--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -188,6 +188,7 @@ size_t InputSplitBase::Read(void *ptr, size_t size) {
     offset_curr_ += n;
     if (nleft == 0) break;
     if (n == 0) {
+      buf[0] = '\n'; ++buf; --nleft;  // insert a newline between files
       if (offset_curr_ != file_offset_[file_ptr_ + 1]) {
         LOG(ERROR) << "curr=" << offset_curr_
                    << ",begin=" << offset_begin_


### PR DESCRIPTION
Currently, when InputSplit loads a directory, it concatenates all files in that directory as one string. This causes an undesirable behavior when one of the files is NOEOL (no end-of-line character at the end of file).

UPDATE: MXNet's [CSV parser](https://github.com/apache/incubator-mxnet/blob/master/src/io/iter_csv.cc) is also affected by this issue, as it relies on the CSV parser implementation in dmlc-core.

Fix: insert '\n' between files

Minimal reproduction: Create three CSV files as follows:
* `train/train_0.csv`: **NOEOL**
```
0,1,1,1
```
* `train/train_1.csv`:
```
0,1,1,2
```
* `train/train_2.csv`:
```
0,1,1,2
```
Then run
```
dtrain = xgboost.DMatrix('train?format=csv')
```
Expected output:
```
3x4 matrix with 12 entries loaded from train?format=csv
```
Actual output:
```
2x7 matrix with 11 entries loaded from train?format=csv
```