### PR TITLE
fix memory leak

### DIFF
--- a/include/dmlc/any.h
+++ b/include/dmlc/any.h
@@ -355,7 +355,7 @@ class any::TypeInfo
   Type type_;
   // constructor
   TypeInfo() {
-    if (std::is_pod<T>::value) {
+    if (std::is_pod<T>::value && data_on_stack<T>::value) {
       type_.destroy = nullptr;
     } else {
       type_.destroy = TypeInfo<T>::destroy;


### PR DESCRIPTION
do not set the destructor for the type objects to null if they are assigned
on heap.

fixes apache/incubator-mxnet#10399