### PR TITLE
(redux) Handle NOEOL files in partitioned text data files [don't merge yet]

### DIFF
--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -177,7 +177,9 @@ void InputSplitBase::InitInputFileInfo(const std::string& uri,
 size_t InputSplitBase::Read(void *ptr, size_t size) {
   if (offset_begin_ >= offset_end_) return 0;
   if (offset_curr_ +  size > offset_end_) {
-    size = offset_end_ - offset_curr_;
+    // allow for extra newlines between files
+    const size_t num_extra_eol = files_.size() - file_ptr_ - 1;
+    size = offset_end_ - offset_curr_ + num_extra_eol;
   }
   if (size == 0) return 0;
   size_t nleft = size;


### PR DESCRIPTION
This is a follow-up of PR #385, which introduced a subtle bug that caused a long line to be sliced off. The reason is that extra newlines were being counted as part of bytes to be read (`nleft` variable), when they should not be.

Fix: Account for extra newlines separately, so that they don't count toward the number of requested bytes.

Minimal reproduction: Create five text files named `test/test_0.libsvm`, `test/test_1.libsvm`, `test/test_2.libsvm`, `test/test_3.libsvm`, `test/test_4.libsvm`, each of which with the content
```
1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1
```
Expected output:
```
5x125 matrix with 110 entries loaded from test
```
Actual output:
```
XGBoostError: b'[08:55:48] /Users/chyunsu/Desktop/xgboost/dmlc-core/src/data/./row_block.h:177: 
Check failed: offset.back() == value.size() || value.size() == 0

Stack trace returned 2 entries:
[bt] (0) 0   libxgboost.dylib                    0x000000010b06115c dmlc::StackTrace[abi:cxx11]() + 364
[bt] (1) 1   libstdc++.6.dylib                   0x000000010b48ef80 vtable for std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> > + 16
```