### PR TITLE
Support multiple types in parser

### DIFF
--- a/src/data/basic_row_iter.h
+++ b/src/data/basic_row_iter.h
@@ -20,10 +20,10 @@ namespace data {
  * \brief basic set of row iterators that provides
  * \tparam IndexType the type of index we are using
  */
-template<typename IndexType>
-class BasicRowIter: public RowBlockIter<IndexType> {
+template<typename IndexType, typename DType = real_t>
+class BasicRowIter: public RowBlockIter<IndexType, DType> {
  public:
-  explicit BasicRowIter(Parser<IndexType> *parser)
+  explicit BasicRowIter(Parser<IndexType, DType> *parser)
       : at_head_(true) {
     this->Init(parser);
     delete parser;
@@ -40,7 +40,7 @@ class BasicRowIter: public RowBlockIter<IndexType> {
       return false;
     }
   }
-  virtual const RowBlock<IndexType> &Value(void) const {
+  virtual const RowBlock<IndexType, DType> &Value(void) const {
     return row_;
   }
   virtual size_t NumCol(void) const {
@@ -51,15 +51,15 @@ class BasicRowIter: public RowBlockIter<IndexType> {
   // at head
   bool at_head_;
   // row block to store
-  RowBlock<IndexType> row_;
+  RowBlock<IndexType, DType> row_;
   // back end data
-  RowBlockContainer<IndexType> data_;
+  RowBlockContainer<IndexType, DType> data_;
   // initialize
-  inline void Init(Parser<IndexType> *parser);
+  inline void Init(Parser<IndexType, DType> *parser);
 };
 
-template<typename IndexType>
-inline void BasicRowIter<IndexType>::Init(Parser<IndexType> *parser) {
+template<typename IndexType, typename DType>
+inline void BasicRowIter<IndexType, DType>::Init(Parser<IndexType, DType> *parser) {
   data_.Clear();
   double tstart = GetTime();
   size_t bytes_expect = 10UL << 20UL;

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -40,13 +40,13 @@ struct CSVParserParam : public Parameter<CSVParserParam> {
  *
  *  This should be extended in future to accept arguments of column types.
  */
-template <typename IndexType>
-class CSVParser : public TextParserBase<IndexType> {
+template <typename IndexType, typename DType = real_t>
+class CSVParser : public TextParserBase<IndexType, DType> {
  public:
   explicit CSVParser(InputSplit *source,
                      const std::map<std::string, std::string>& args,
                      int nthread)
-      : TextParserBase<IndexType>(source, nthread) {
+      : TextParserBase<IndexType, DType>(source, nthread) {
     param_.Init(args);
     CHECK_EQ(param_.format, "csv");
   }
@@ -54,17 +54,17 @@ class CSVParser : public TextParserBase<IndexType> {
  protected:
   virtual void ParseBlock(const char *begin,
                           const char *end,
-                          RowBlockContainer<IndexType> *out);
+                          RowBlockContainer<IndexType, DType> *out);
 
  private:
   CSVParserParam param_;
 };
 
-template <typename IndexType>
-void CSVParser<IndexType>::
+template <typename IndexType, typename DType>
+void CSVParser<IndexType, DType>::
 ParseBlock(const char *begin,
            const char *end,
-           RowBlockContainer<IndexType> *out) {
+           RowBlockContainer<IndexType, DType> *out) {
   out->Clear();
   const char * lbegin = begin;
   const char * lend = lbegin;
@@ -79,11 +79,21 @@ ParseBlock(const char *begin,
     const char* p = lbegin;
     int column_index = 0;
     IndexType idx = 0;
-    float label = 0.0f;
+    DType label = DType(0.0f);
 
     while (p != lend) {
       char *endptr;
-      float v = strtof(p, &endptr);
+      DType v;
+      // if DType is float32
+      if (std::is_same<DType, real_t>::value) {
+        v = strtof(p, &endptr);
+      // If DType is int32
+      } else if (std::is_same<DType, int>::value) {
+        v = static_cast<int>(strtol(p, &endptr, 0));
+      // If DType is all other types
+      } else {
+        LOG(FATAL) << "Only float32 and int32 are supported for the time being";
+      }
       p = (endptr >= lend) ? lend : endptr;
 
       if (column_index == param_.label_column) {

--- a/src/data/libfm_parser.h
+++ b/src/data/libfm_parser.h
@@ -19,8 +19,8 @@ namespace data {
  * \brief Text parser that parses the input lines
  * and returns rows in input data
  */
-template <typename IndexType>
-class LibFMParser : public TextParserBase<IndexType> {
+template <typename IndexType, typename DType = real_t>
+class LibFMParser : public TextParserBase<IndexType, DType> {
  public:
   explicit LibFMParser(InputSplit *source,
                         int nthread)
@@ -29,14 +29,14 @@ class LibFMParser : public TextParserBase<IndexType> {
  protected:
   virtual void ParseBlock(const char *begin,
                           const char *end,
-                          RowBlockContainer<IndexType> *out);
+                          RowBlockContainer<IndexType, DType> *out);
 };
 
-template <typename IndexType>
-void LibFMParser<IndexType>::
+template <typename IndexType, typename DType>
+void LibFMParser<IndexType, DType>::
 ParseBlock(const char *begin,
            const char *end,
-           RowBlockContainer<IndexType> *out) {
+           RowBlockContainer<IndexType, DType> *out) {
   out->Clear();
   const char * lbegin = begin;
   const char * lend = lbegin;

--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -19,7 +19,7 @@ namespace data {
  * \brief Text parser that parses the input lines
  * and returns rows in input data
  */
-template <typename IndexType>
+template <typename IndexType, typename DType = real_t>
 class LibSVMParser : public TextParserBase<IndexType> {
  public:
   explicit LibSVMParser(InputSplit *source,
@@ -29,14 +29,14 @@ class LibSVMParser : public TextParserBase<IndexType> {
  protected:
   virtual void ParseBlock(const char *begin,
                           const char *end,
-                          RowBlockContainer<IndexType> *out);
+                          RowBlockContainer<IndexType, DType> *out);
 };
 
-template <typename IndexType>
-void LibSVMParser<IndexType>::
+template <typename IndexType, typename DType>
+void LibSVMParser<IndexType, DType>::
 ParseBlock(const char *begin,
            const char *end,
-           RowBlockContainer<IndexType> *out) {
+           RowBlockContainer<IndexType, DType> *out) {
   out->Clear();
   const char * lbegin = begin;
   const char * lend = lbegin;

--- a/src/data/text_parser.h
+++ b/src/data/text_parser.h
@@ -21,8 +21,8 @@ namespace data {
  * \brief Text parser that parses the input lines
  * and returns rows in input data
  */
-template <typename IndexType>
-class TextParserBase : public ParserImpl<IndexType> {
+template <typename IndexType, typename DType = real_t>
+class TextParserBase : public ParserImpl<IndexType, DType> {
  public:
   explicit TextParserBase(InputSplit *source,
                           int nthread)
@@ -39,7 +39,7 @@ class TextParserBase : public ParserImpl<IndexType> {
   virtual size_t BytesRead(void) const {
     return bytes_read_;
   }
-  virtual bool ParseNext(std::vector<RowBlockContainer<IndexType> > *data) {
+  virtual bool ParseNext(std::vector<RowBlockContainer<IndexType, DType> > *data) {
     return FillData(data);
   }
 
@@ -50,13 +50,13 @@ class TextParserBase : public ParserImpl<IndexType> {
     * \param end end of buffer
     */
   virtual void ParseBlock(const char *begin, const char *end,
-                          RowBlockContainer<IndexType> *out) = 0;
+                          RowBlockContainer<IndexType, DType> *out) = 0;
    /*!
     * \brief read in next several blocks of data
     * \param data vector of data to be returned
     * \return true if the data is loaded, false if reach end
     */
-  inline bool FillData(std::vector<RowBlockContainer<IndexType>> *data);
+  inline bool FillData(std::vector<RowBlockContainer<IndexType, DType>> *data);
    /*!
     * \brief start from bptr, go backward and find first endof line
     * \param bptr end position to go backward
@@ -105,9 +105,9 @@ class TextParserBase : public ParserImpl<IndexType> {
 };
 
 // implementation
-template <typename IndexType>
-inline bool TextParserBase<IndexType>::FillData(
-    std::vector<RowBlockContainer<IndexType> > *data) {
+template <typename IndexType, typename DType>
+inline bool TextParserBase<IndexType, DType>::FillData(
+    std::vector<RowBlockContainer<IndexType, DType> > *data) {
   InputSplit::Blob chunk;
   if (!source_->NextChunk(&chunk)) return false;
   const int nthread = omp_get_max_threads();

--- a/test/csv_parser_test.cc
+++ b/test/csv_parser_test.cc
@@ -19,8 +19,8 @@ int main(int argc, char *argv[]) {
     }
   }
   using namespace dmlc;
-  std::unique_ptr<dmlc::Parser<unsigned> > parser(
-      dmlc::Parser<unsigned>::Create(argv[1],
+  std::unique_ptr<dmlc::Parser<unsigned, int> > parser(
+      dmlc::Parser<unsigned, int>::Create(argv[1],
                                      atoi(argv[2]),
                                      atoi(argv[3]),
                                      "csv"));
@@ -34,10 +34,10 @@ int main(int argc, char *argv[]) {
     bytes_read  = parser->BytesRead();
     num_ex += parser->Value().size;
     if (fo != NULL){
-      const dmlc::RowBlock<unsigned>& batch = parser->Value();
+      const dmlc::RowBlock<unsigned, int>& batch = parser->Value();
       for (size_t i = 0; i < batch.size; ++i) {
         for (size_t j = 0; j < batch[i].length; ++j) {
-          fprintf(fo, "%g", batch[i].value[j]);
+          fprintf(fo, "%d", batch[i].value[j]);
           if (j + 1 == batch[i].length) {
             fprintf(fo, "\n");
           } else {

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -8,16 +8,16 @@ using namespace dmlc;
 using namespace dmlc::data;
 
 namespace parser_test {
-template <typename IndexType>
-class CSVParserTest : public CSVParser<IndexType> {
+template <typename IndexType, typename DType = real_t>
+class CSVParserTest : public CSVParser<IndexType, DType> {
 public:
   explicit CSVParserTest(InputSplit *source,
                          const std::map<std::string, std::string> &args,
                          int nthread)
-      : CSVParser<IndexType>(source, args, nthread) {}
+      : CSVParser<IndexType, DType>(source, args, nthread) {}
   void CallParseBlock(char *begin, char *end,
-                      RowBlockContainer<IndexType> *out) {
-    CSVParser<IndexType>::ParseBlock(begin, end, out);
+                      RowBlockContainer<IndexType, DType> *out) {
+    CSVParser<IndexType, DType>::ParseBlock(begin, end, out);
   }
 };
 
@@ -56,6 +56,23 @@ TEST(CSVParser, test_standard_case) {
   parser->CallParseBlock(out_data, out_data + data.size(), rctr);
   for (size_t i = 0; i < rctr->value.size(); i++) {
     CHECK(i == rctr->value[i]);
+  }
+}
+
+TEST(CSVParser, test_integer_parse) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
+  std::unique_ptr<CSVParserTest<unsigned, int>> parser(
+      new CSVParserTest<unsigned, int>(source, args, 1));
+  RowBlockContainer<unsigned, int> *rctr = new RowBlockContainer<unsigned, int>();
+  std::string data = "20000000,20000001,20000002,20000003\n"
+                     "20000004,20000005,20000006,20000007\n"
+                     "20000008,20000009,20000010,20000011\n";
+  char *out_data = const_cast<char *>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+  for (size_t i = 0; i < rctr->value.size(); i++) {
+    CHECK((i+20000000) == rctr->value[i]);
   }
 }
 


### PR DESCRIPTION
The only supported type in parser is real_t (aka float), which does not work fine when user want to read in large integers. For example, integer 20000001 will have the same float32 representation as 20000000. As a result, we need the parser to able be able to parse the input files in other forms such as integers.
This PR adds template to all related classes and functions to support multiple types in parsers.
