### PR TITLE
(redux) Handle NOEOL files in partitioned text data files

### DIFF
--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -177,7 +177,9 @@ void InputSplitBase::InitInputFileInfo(const std::string& uri,
 size_t InputSplitBase::Read(void *ptr, size_t size) {
   if (offset_begin_ >= offset_end_) return 0;
   if (offset_curr_ +  size > offset_end_) {
-    size = offset_end_ - offset_curr_;
+    // allow for extra newlines between files
+    const size_t num_extra_eol = files_.size() - file_ptr_ - 1;
+    size = offset_end_ - offset_curr_ + num_extra_eol;
   }
   if (size == 0) return 0;
   size_t nleft = size;

--- a/test/unittest/unittest_inputsplit.cc
+++ b/test/unittest/unittest_inputsplit.cc
@@ -1,0 +1,131 @@
+#include "../src/data/csv_parser.h"
+#include "../src/data/libsvm_parser.h"
+#include "../include/dmlc/data.h"
+#include <string>
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cstdlib>
+#include <unistd.h>
+#include <gtest/gtest.h>
+
+static inline void CountDimensions(dmlc::Parser<uint32_t>* parser,
+                                   size_t* out_num_row, size_t* out_num_col) {
+  size_t num_row = 0;
+  size_t num_col = 0;
+  while (parser->Next()) {
+    const dmlc::RowBlock<uint32_t>& batch = parser->Value();
+    num_row += batch.size;
+    for (size_t i = batch.offset[0]; i < batch.offset[batch.size]; ++i) {
+      const uint32_t index = batch.index[i];
+      num_col = std::max(num_col, static_cast<size_t>(index + 1));
+    }
+  }
+  *out_num_row = num_row;
+  *out_num_col = num_col;
+}
+
+class TemporaryDirectory {
+ public:
+  TemporaryDirectory() {
+    std::string tmproot; /* root directory of temporary area */
+    std::string dirtemplate; /* template for temporary directory name */
+    /* Get TMPDIR env variable or fall back to /tmp/ */
+    {
+      const char* tmpenv = getenv("TMPDIR");
+      if (tmpenv) {
+        tmproot = std::string(tmpenv);
+        // strip trailing forward slashes
+        while (tmproot.length() != 0 && tmproot[tmproot.length() - 1] == '/') {
+          tmproot.resize(tmproot.length() - 1);
+        }
+      } else {
+        tmproot = "/tmp";
+      }
+    }
+    dirtemplate = tmproot + "/tmpdir.XXXXXX";
+    std::vector<char> dirtemplate_buf(dirtemplate.begin(), dirtemplate.end());
+    dirtemplate_buf.push_back('\0');
+    char* tmpdir = mkdtemp(&dirtemplate_buf[0]);
+    if (!tmpdir) {
+      std::cerr << "TemporaryDirectory(): "
+                << "Could not create temporary directory" << std::endl;
+      exit(-1);
+    }
+    path = std::string(tmpdir);
+    std::cerr << "Created temporary directory " << path << std::endl;
+  }
+  ~TemporaryDirectory() {
+    if (rmdir(path.c_str()) == -1) {
+      std::cerr << "~TemporaryDirectory(): "
+                << "Could not remove temporary directory " << path << std::endl;
+      exit(-1);
+    }
+    std::cerr << "Successfully deleted temporary directory " << path << std::endl;
+  }
+  std::string path;
+};
+
+TEST(InputSplit, test_split_csv_noeol) {
+  size_t num_row, num_col;
+  {
+    /* Create a test case for partitioned csv with NOEOL */
+    TemporaryDirectory tempdir;
+    {
+      std::string filename = tempdir.path + "/train_0.csv";
+      std::ofstream of(filename.c_str(), std::ios::binary);
+      of << "0,1,1,1";  // NOEOL (no '\n' at end of file)
+    }
+    {
+      std::string filename = tempdir.path + "/train_1.csv";
+      std::ofstream of(filename.c_str(), std::ios::binary);
+      of << "0,1,1,2\n";
+    }
+    {
+      std::string filename = tempdir.path + "/train_2.csv";
+      std::ofstream of(filename.c_str(), std::ios::binary);
+      of << "0,1,1,2\n";
+    }
+    /* Load the test case with InputSplit and obtain matrix dimensions */
+    std::unique_ptr<dmlc::Parser<uint32_t> > parser(
+          dmlc::Parser<uint32_t>::Create(tempdir.path.c_str(), 0, 1, "csv"));
+    CountDimensions(parser.get(), &num_row, &num_col);
+    /* Clean up */
+    for (int i = 0; i < 3; ++i) {
+      std::string filename
+        = tempdir.path + "/train_" + std::to_string(i) + ".csv";
+      std::remove(filename.c_str());
+    }
+  }
+  /* Check matrix dimensions: must be 3x4 */
+  ASSERT_EQ(num_row, 3U);
+  ASSERT_EQ(num_col, 4U);
+}
+
+TEST(InputSplit, test_split_libsvm) {
+  size_t num_row, num_col;
+  {
+    /* Create a test case for partitioned libsvm */
+    TemporaryDirectory tempdir;
+    for (int i = 0; i < 5; ++i) {
+      std::string filename
+        = tempdir.path + "/test_" + std::to_string(i) + ".libsvm";
+      std::ofstream of(filename.c_str(), std::ios::binary);
+      of << "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
+         << "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1\n";
+    }
+    /* Load the test case with InputSplit and obtain matrix dimensions */
+    std::unique_ptr<dmlc::Parser<uint32_t> > parser(
+          dmlc::Parser<uint32_t>::Create(tempdir.path.c_str(), 0, 1, "libsvm"));
+    CountDimensions(parser.get(), &num_row, &num_col);
+    /* Clean up */
+    for (int i = 0; i < 5; ++i) {
+      std::string filename
+        = tempdir.path + "/test_" + std::to_string(i) + ".libsvm";
+      std::remove(filename.c_str());
+    }
+  }
+  /* Check matrix dimensions: must be 5x125 */
+  ASSERT_EQ(num_row, 5U);
+  ASSERT_EQ(num_col, 125U);
+}


### PR DESCRIPTION
This is a follow-up of PR #385, which introduced a subtle bug that caused a long line to be sliced off.

Diagnosis:
When `InputSplitBase::Read()` is requested to read more bytes than available by all underlying files, the method infers the number of bytes to read using the file offsets. This logic did not account of the extra newlines to be inserted by PR #385.

Minimal reproduction:
Create five text files named `test/test_0.libsvm`, `test/test_1.libsvm`, `test/test_2.libsvm`, `test/test_3.libsvm`, `test/test_4.libsvm`, each of which with the content
```
1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1
```
And then run
```python
dtrain = xgboost.DMatrix('test')
```

Expected output:
```
5x125 matrix with 110 entries loaded from test
```
Actual output:
```
XGBoostError:
[08:55:48] /Users/chyunsu/Desktop/xgboost/dmlc-core/src/data/./row_block.h:177: Check failed: offset.back() == value.size() || value.size() == 0

Stack trace returned 2 entries:
[bt] (0) 0   libxgboost.dylib                    0x000000010b06115c dmlc::StackTrace[abi:cxx11]() + 364
[bt] (1) 1   libstdc++.6.dylib                   0x000000010b48ef80 vtable for std::__cxx11::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> > + 16
```