### PR TITLE
Include standard headers in text parser

### DIFF
--- a/src/data/text_parser.h
+++ b/src/data/text_parser.h
@@ -9,6 +9,8 @@
 
 #include <dmlc/data.h>
 #include <dmlc/omp.h>
+#include <thread>
+#include <mutex>
 #include <vector>
 #include <cstring>
 #include <algorithm>


### PR DESCRIPTION
Some compilers (e.g. MinGW64) failed to compile text parser because a few standard headers were not included.