### PR TITLE
Add indexing_mode option to libsvm and libfm parser

### DIFF
--- a/src/data.cc
+++ b/src/data.cc
@@ -26,7 +26,7 @@ CreateLibSVMParser(const std::string& path,
                    unsigned num_parts) {
   InputSplit* source = InputSplit::Create(
       path.c_str(), part_index, num_parts, "text");
-  ParserImpl<IndexType> *parser = new LibSVMParser<IndexType>(source, 2);
+  ParserImpl<IndexType> *parser = new LibSVMParser<IndexType>(source, args, 2);
 #if DMLC_ENABLE_STD_THREAD
   parser = new ThreadedParser<IndexType>(parser);
 #endif
@@ -41,7 +41,7 @@ CreateLibFMParser(const std::string& path,
                   unsigned num_parts) {
   InputSplit* source = InputSplit::Create(
       path.c_str(), part_index, num_parts, "text");
-  ParserImpl<IndexType> *parser = new LibFMParser<IndexType>(source, 2);
+  ParserImpl<IndexType> *parser = new LibFMParser<IndexType>(source, args, 2);
 #if DMLC_ENABLE_STD_THREAD
   parser = new ThreadedParser<IndexType>(parser);
 #endif
@@ -106,6 +106,8 @@ CreateIter_(const char *uri_,
   }
 }
 
+DMLC_REGISTER_PARAMETER(LibSVMParserParam);
+DMLC_REGISTER_PARAMETER(LibFMParserParam);
 DMLC_REGISTER_PARAMETER(CSVParserParam);
 }  // namespace data
 

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -28,7 +28,7 @@ struct CSVParserParam : public Parameter<CSVParserParam> {
     DMLC_DECLARE_FIELD(format).set_default("csv")
         .describe("File format.");
     DMLC_DECLARE_FIELD(label_column).set_default(-1)
-        .describe("Column index that will put into label.");
+        .describe("Column index (0-based) that will put into label.");
     DMLC_DECLARE_FIELD(delimiter).set_default(",")
       .describe("Delimiter used in the csv file.");
   }

--- a/src/data/libfm_parser.h
+++ b/src/data/libfm_parser.h
@@ -15,6 +15,24 @@
 
 namespace dmlc {
 namespace data {
+
+struct LibFMParserParam : public Parameter<LibFMParserParam> {
+  std::string format;
+  int indexing_mode;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(LibFMParserParam) {
+    DMLC_DECLARE_FIELD(format).set_default("libfm")
+        .describe("File format");
+    DMLC_DECLARE_FIELD(indexing_mode).set_default(-1)
+        .describe(
+          "If >0, treat all field and feature indices as 1-based. "
+          "If <0, treat all field and feature indices as 0-based. "
+          "If =0, use heuristic to automatically detect mode of indexing. "
+          "See https://en.wikipedia.org/wiki/Array_data_type#Index_origin "
+          "for more details on indexing modes.");
+  }
+};
+
 /*!
  * \brief Text parser that parses the input lines
  * and returns rows in input data
@@ -22,14 +40,23 @@ namespace data {
 template <typename IndexType, typename DType = real_t>
 class LibFMParser : public TextParserBase<IndexType, DType> {
  public:
+ explicit LibFMParser(InputSplit *source, int nthread)
+      : LibFMParser(source, std::map<std::string, std::string>(), nthread) {}
   explicit LibFMParser(InputSplit *source,
-                        int nthread)
-      : TextParserBase<IndexType>(source, nthread) {}
+                       const std::map<std::string, std::string>& args,
+                       int nthread)
+      : TextParserBase<IndexType>(source, nthread) {
+    param_.Init(args);
+    CHECK_EQ(param_.format, "libfm");
+  }
 
  protected:
   virtual void ParseBlock(const char *begin,
                           const char *end,
                           RowBlockContainer<IndexType, DType> *out);
+
+ private:
+  LibFMParserParam param_;
 };
 
 template <typename IndexType, typename DType>
@@ -40,6 +67,8 @@ ParseBlock(const char *begin,
   out->Clear();
   const char * lbegin = begin;
   const char * lend = lbegin;
+  IndexType min_field_id = std::numeric_limits<IndexType>::max();
+  IndexType min_feat_id = std::numeric_limits<IndexType>::max();
   while (lbegin != end) {
     // get line end
     lend = lbegin + 1;
@@ -76,6 +105,8 @@ ParseBlock(const char *begin,
       }
       out->field.push_back(fieldId);
       out->index.push_back(featureId);
+      min_field_id = std::min(fieldId, min_field_id);
+      min_feat_id = std::min(featureId, min_feat_id);
       if (r == 3) {
         // has value
         out->value.push_back(value);
@@ -90,6 +121,21 @@ ParseBlock(const char *begin,
   }
   CHECK(out->field.size() == out->index.size());
   CHECK(out->label.size() + 1 == out->offset.size());
+
+  // detect indexing mode
+  // heuristic adopted from sklearn.datasets.load_svmlight_file
+  // If all feature and field id's exceed 0, then detect 1-based indexing
+  if (param_.indexing_mode > 0
+      || (param_.indexing_mode == 0 && !out->index.empty() && min_feat_id > 0
+          && !out->field.empty() && min_field_id > 0) ) {
+    // convert from 1-based to 0-based indexing
+    for (IndexType& e : out->index) {
+      --e;
+    }
+    for (IndexType& e : out->field) {
+      --e;
+    }
+  }
 }
 
 }  // namespace data

--- a/src/data/libfm_parser.h
+++ b/src/data/libfm_parser.h
@@ -8,6 +8,11 @@
 #define DMLC_DATA_LIBFM_PARSER_H_
 
 #include <dmlc/data.h>
+#include <dmlc/parameter.h>
+#include <map>
+#include <string>
+#include <limits>
+#include <algorithm>
 #include <cstring>
 #include "./row_block.h"
 #include "./text_parser.h"
@@ -40,7 +45,7 @@ struct LibFMParserParam : public Parameter<LibFMParserParam> {
 template <typename IndexType, typename DType = real_t>
 class LibFMParser : public TextParserBase<IndexType, DType> {
  public:
- explicit LibFMParser(InputSplit *source, int nthread)
+  explicit LibFMParser(InputSplit *source, int nthread)
       : LibFMParser(source, std::map<std::string, std::string>(), nthread) {}
   explicit LibFMParser(InputSplit *source,
                        const std::map<std::string, std::string>& args,

--- a/src/data/libfm_parser.h
+++ b/src/data/libfm_parser.h
@@ -28,11 +28,11 @@ struct LibFMParserParam : public Parameter<LibFMParserParam> {
   DMLC_DECLARE_PARAMETER(LibFMParserParam) {
     DMLC_DECLARE_FIELD(format).set_default("libfm")
         .describe("File format");
-    DMLC_DECLARE_FIELD(indexing_mode).set_default(-1)
+    DMLC_DECLARE_FIELD(indexing_mode).set_default(0)
         .describe(
           "If >0, treat all field and feature indices as 1-based. "
-          "If <0, treat all field and feature indices as 0-based. "
-          "If =0, use heuristic to automatically detect mode of indexing. "
+          "If =0, treat all field and feature indices as 0-based. "
+          "If <0, use heuristic to automatically detect mode of indexing. "
           "See https://en.wikipedia.org/wiki/Array_data_type#Index_origin "
           "for more details on indexing modes.");
   }
@@ -131,7 +131,7 @@ ParseBlock(const char *begin,
   // heuristic adopted from sklearn.datasets.load_svmlight_file
   // If all feature and field id's exceed 0, then detect 1-based indexing
   if (param_.indexing_mode > 0
-      || (param_.indexing_mode == 0 && !out->index.empty() && min_feat_id > 0
+      || (param_.indexing_mode < 0 && !out->index.empty() && min_feat_id > 0
           && !out->field.empty() && min_field_id > 0) ) {
     // convert from 1-based to 0-based indexing
     for (IndexType& e : out->index) {

--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -8,6 +8,8 @@
 #define DMLC_DATA_LIBSVM_PARSER_H_
 
 #include <dmlc/data.h>
+#include <dmlc/parameter.h>
+#include <limits>
 #include <cstring>
 #include "./row_block.h"
 #include "./text_parser.h"
@@ -15,6 +17,24 @@
 
 namespace dmlc {
 namespace data {
+
+struct LibSVMParserParam : public Parameter<LibSVMParserParam> {
+  std::string format;
+  int indexing_mode;
+  // declare parameters
+  DMLC_DECLARE_PARAMETER(LibSVMParserParam) {
+    DMLC_DECLARE_FIELD(format).set_default("libsvm")
+        .describe("File format");
+    DMLC_DECLARE_FIELD(indexing_mode).set_default(-1)
+        .describe(
+          "If >0, treat all feature indices as 1-based. "
+          "If <0, treat all feature indices as 0-based. "
+          "If =0, use heuristic to automatically detect mode of indexing. "
+          "See https://en.wikipedia.org/wiki/Array_data_type#Index_origin "
+          "for more details on indexing modes.");
+  }
+};
+
 /*!
  * \brief Text parser that parses the input lines
  * and returns rows in input data
@@ -22,14 +42,23 @@ namespace data {
 template <typename IndexType, typename DType = real_t>
 class LibSVMParser : public TextParserBase<IndexType> {
  public:
+  explicit LibSVMParser(InputSplit *source, int nthread)
+      : LibSVMParser(source, std::map<std::string, std::string>(), nthread) {}
   explicit LibSVMParser(InputSplit *source,
+                        const std::map<std::string, std::string>& args,
                         int nthread)
-      : TextParserBase<IndexType>(source, nthread) {}
+      : TextParserBase<IndexType>(source, nthread) {
+    param_.Init(args);
+    CHECK_EQ(param_.format, "libsvm");
+  }
 
  protected:
   virtual void ParseBlock(const char *begin,
                           const char *end,
                           RowBlockContainer<IndexType, DType> *out);
+
+ private:
+  LibSVMParserParam param_;
 };
 
 template <typename IndexType, typename DType>
@@ -40,6 +69,7 @@ ParseBlock(const char *begin,
   out->Clear();
   const char * lbegin = begin;
   const char * lend = lbegin;
+  IndexType min_feat_id = std::numeric_limits<IndexType>::max();
   while (lbegin != end) {
     // get line end
     lend = lbegin + 1;
@@ -83,6 +113,7 @@ ParseBlock(const char *begin,
         continue;
       }
       out->index.push_back(featureId);
+      min_feat_id = std::min(featureId, min_feat_id);
       if (r == 2) {
         // has value
         out->value.push_back(value);
@@ -96,6 +127,17 @@ ParseBlock(const char *begin,
     out->offset.push_back(out->index.size());
   }
   CHECK(out->label.size() + 1 == out->offset.size());
+
+  // detect indexing mode
+  // heuristic adopted from sklearn.datasets.load_svmlight_file
+  // If all feature id's exceed 0, then detect 1-based indexing
+  if (param_.indexing_mode > 0
+      || (param_.indexing_mode == 0 && !out->index.empty() && min_feat_id > 0)) {
+    // convert from 1-based to 0-based indexing
+    for (IndexType& e : out->index) {
+      --e;
+    }
+  }
 }
 
 }  // namespace data

--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -28,11 +28,11 @@ struct LibSVMParserParam : public Parameter<LibSVMParserParam> {
   DMLC_DECLARE_PARAMETER(LibSVMParserParam) {
     DMLC_DECLARE_FIELD(format).set_default("libsvm")
         .describe("File format");
-    DMLC_DECLARE_FIELD(indexing_mode).set_default(-1)
+    DMLC_DECLARE_FIELD(indexing_mode).set_default(0)
         .describe(
           "If >0, treat all feature indices as 1-based. "
-          "If <0, treat all feature indices as 0-based. "
-          "If =0, use heuristic to automatically detect mode of indexing. "
+          "If =0, treat all feature indices as 0-based. "
+          "If <0, use heuristic to automatically detect mode of indexing. "
           "See https://en.wikipedia.org/wiki/Array_data_type#Index_origin "
           "for more details on indexing modes.");
   }
@@ -135,7 +135,7 @@ ParseBlock(const char *begin,
   // heuristic adopted from sklearn.datasets.load_svmlight_file
   // If all feature id's exceed 0, then detect 1-based indexing
   if (param_.indexing_mode > 0
-      || (param_.indexing_mode == 0 && !out->index.empty() && min_feat_id > 0)) {
+      || (param_.indexing_mode < 0 && !out->index.empty() && min_feat_id > 0)) {
     // convert from 1-based to 0-based indexing
     for (IndexType& e : out->index) {
       --e;

--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -9,7 +9,10 @@
 
 #include <dmlc/data.h>
 #include <dmlc/parameter.h>
+#include <map>
+#include <string>
 #include <limits>
+#include <algorithm>
 #include <cstring>
 #include "./row_block.h"
 #include "./text_parser.h"

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -278,7 +278,7 @@ TEST(LibSVMParser, test_indexing_mode_1_based) {
 TEST(LibSVMParser, test_indexing_mode_auto_detect) {
   using namespace parser_test;
   InputSplit *source = nullptr;
-  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  const std::map<std::string, std::string> args{{"indexing_mode", "-1"}};
   std::unique_ptr<LibSVMParserTest<unsigned>> parser(
       new LibSVMParserTest<unsigned>(source, args, 1));
   RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
@@ -301,7 +301,7 @@ TEST(LibSVMParser, test_indexing_mode_auto_detect) {
 TEST(LibSVMParser, test_indexing_mode_auto_detect_2) {
   using namespace parser_test;
   InputSplit *source = nullptr;
-  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  const std::map<std::string, std::string> args{{"indexing_mode", "-1"}};
   std::unique_ptr<LibSVMParserTest<unsigned>> parser(
       new LibSVMParserTest<unsigned>(source, args, 1));
   RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
@@ -375,7 +375,7 @@ TEST(LibFMParser, test_indexing_mode_1_based) {
 TEST(LibFMParser, test_indexing_mode_auto_detect) {
   using namespace parser_test;
   InputSplit *source = nullptr;
-  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  const std::map<std::string, std::string> args{{"indexing_mode", "-1"}};
   std::unique_ptr<LibFMParserTest<unsigned>> parser(
       new LibFMParserTest<unsigned>(source, args, 1));
   RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
@@ -401,7 +401,7 @@ TEST(LibFMParser, test_indexing_mode_auto_detect) {
 TEST(LibFMParser, test_indexing_mode_auto_detect_2) {
   using namespace parser_test;
   InputSplit *source = nullptr;
-  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  const std::map<std::string, std::string> args{{"indexing_mode", "-1"}};
   std::unique_ptr<LibFMParserTest<unsigned>> parser(
       new LibFMParserTest<unsigned>(source, args, 1));
   RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -1,5 +1,6 @@
 #include "../src/data/csv_parser.h"
 #include "../src/data/libsvm_parser.h"
+#include "../src/data/libfm_parser.h"
 #include <cstdio>
 #include <cstdlib>
 #include <dmlc/io.h>
@@ -25,15 +26,47 @@ public:
 template <typename IndexType, typename DType = real_t>
 class LibSVMParserTest : public LibSVMParser<IndexType, DType> {
 public:
-  explicit LibSVMParserTest(InputSplit *source, int nthread)
-      : LibSVMParser<IndexType, DType>(source, nthread) {}
+  explicit LibSVMParserTest(InputSplit *source,
+                            const std::map<std::string, std::string> &args,
+                            int nthread)
+      : LibSVMParser<IndexType, DType>(source, args, nthread) {}
   void CallParseBlock(char *begin, char *end,
                       RowBlockContainer<IndexType, DType> *out) {
     LibSVMParser<IndexType, DType>::ParseBlock(begin, end, out);
   }
 };
 
+template <typename IndexType, typename DType = real_t>
+class LibFMParserTest : public LibFMParser<IndexType, DType> {
+public:
+  explicit LibFMParserTest(InputSplit *source,
+                           const std::map<std::string, std::string> &args,
+                           int nthread)
+      : LibFMParser<IndexType, DType>(source, args, nthread) {}
+  void CallParseBlock(char *begin, char *end,
+                      RowBlockContainer<IndexType, DType> *out) {
+    LibFMParser<IndexType, DType>::ParseBlock(begin, end, out);
+  }
+};
+
+}  // namespace parser_test
+
+namespace {
+
+template <typename IndexType>
+static inline void CountDimensions(RowBlockContainer<IndexType>* rctr,
+                                   size_t* out_num_row, size_t* out_num_col) {
+  size_t num_row = rctr->label.size();
+  size_t num_col = 0;
+  for (size_t i = rctr->offset[0]; i < rctr->offset[num_row]; ++i) {
+    const IndexType index = rctr->index[i];
+    num_col = std::max(num_col, static_cast<size_t>(index + 1));
+  }
+  *out_num_row = num_row;
+  *out_num_col = num_col;
 }
+
+}  // namespace anonymous
 
 TEST(CSVParser, test_ignore_bom) {
   using namespace parser_test;
@@ -153,8 +186,9 @@ TEST(CSVParser, test_delimiter) {
 TEST(LibSVMParser, test_qid) {
   using namespace parser_test;
   InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
   std::unique_ptr<LibSVMParserTest<unsigned>> parser(
-      new LibSVMParserTest<unsigned>(source, 1));
+      new LibSVMParserTest<unsigned>(source, args, 1));
   RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
   std::string data = R"qid(3 qid:1 1:1 2:1 3:0 4:0.2 5:0
                            2 qid:1 1:0 2:0 3:1 4:0.1 5:1
@@ -194,4 +228,198 @@ TEST(LibSVMParser, test_qid) {
   CHECK(rctr->qid == expected_qid);
   CHECK(rctr->index == expected_index);
   CHECK(rctr->value == expected_value);
+}
+
+TEST(LibSVMParser, test_indexing_mode_0_based) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
+  std::unique_ptr<LibSVMParserTest<unsigned>> parser(
+      new LibSVMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data = "1 1:1 2:-1\n0 1:-1 2:1\n1 1:-1 2:-1\n0 1:1 2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 3U);
+
+  const std::vector<unsigned> expected_index{1, 2, 1, 2, 1, 2, 1, 2};
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->index == expected_index);  // perform element-wise comparsion
+  CHECK(rctr->value == expected_value);
+}
+
+TEST(LibSVMParser, test_indexing_mode_1_based) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "1"}};
+  std::unique_ptr<LibSVMParserTest<unsigned>> parser(
+      new LibSVMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data = "1 1:1 2:-1\n0 1:-1 2:1\n1 1:-1 2:-1\n0 1:1 2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 2U);
+
+  const std::vector<unsigned> expected_index{0, 1, 0, 1, 0, 1, 0, 1};
+    // with indexing_mode=1, parser will subtract 1 from each feature index
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->index == expected_index);  // perform element-wise comparsion
+  CHECK(rctr->value == expected_value);
+}
+
+TEST(LibSVMParser, test_indexing_mode_auto_detect) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  std::unique_ptr<LibSVMParserTest<unsigned>> parser(
+      new LibSVMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data = "1 1:1 2:-1\n0 1:-1 2:1\n1 1:-1 2:-1\n0 1:1 2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 2U);
+
+  const std::vector<unsigned> expected_index{0, 1, 0, 1, 0, 1, 0, 1};
+    // expect to detect 1-based indexing, since the least feature id is 1
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->index == expected_index);  // perform element-wise comparsion
+  CHECK(rctr->value == expected_value);
+}
+
+TEST(LibSVMParser, test_indexing_mode_auto_detect_2) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  std::unique_ptr<LibSVMParserTest<unsigned>> parser(
+      new LibSVMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data = "1 1:1 2:-1\n0 0:-2 1:-1 2:1\n1 1:-1 2:-1\n0 1:1 2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 3U);
+
+  const std::vector<unsigned> expected_index{1, 2, 0, 1, 2, 1, 2, 1, 2};
+    // expect to detect 0-based indexing, since the least feature id is 0
+  const std::vector<real_t> expected_value{1, -1, -2, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->index == expected_index);  // perform element-wise comparsion
+  CHECK(rctr->value == expected_value);
+}
+
+TEST(LibFMParser, test_indexing_mode_0_based) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
+  std::unique_ptr<LibFMParserTest<unsigned>> parser(
+      new LibFMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data
+    = "1 1:1:1 1:2:-1\n0 1:1:-1 2:2:1\n1 2:1:-1 1:2:-1\n0 2:1:1 2:2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 3U);
+
+  const std::vector<unsigned> expected_field{1, 1, 1, 2, 2, 1, 2, 2};
+  const std::vector<unsigned> expected_index{1, 2, 1, 2, 1, 2, 1, 2};
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->field == expected_field);
+  CHECK(rctr->index == expected_index);
+  CHECK(rctr->value == expected_value);  // perform element-wise comparsion
+}
+
+TEST(LibFMParser, test_indexing_mode_1_based) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "1"}};
+  std::unique_ptr<LibFMParserTest<unsigned>> parser(
+      new LibFMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data
+    = "1 1:1:1 1:2:-1\n0 1:1:-1 2:2:1\n1 2:1:-1 1:2:-1\n0 2:1:1 2:2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 2U);
+
+  const std::vector<unsigned> expected_field{0, 0, 0, 1, 1, 0, 1, 1};
+  const std::vector<unsigned> expected_index{0, 1, 0, 1, 0, 1, 0, 1};
+    // with indexing_mode=1, parser will subtract 1 from field/feature indices
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->field == expected_field);
+  CHECK(rctr->index == expected_index);
+  CHECK(rctr->value == expected_value);  // perform element-wise comparsion
+}
+
+TEST(LibFMParser, test_indexing_mode_auto_detect) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  std::unique_ptr<LibFMParserTest<unsigned>> parser(
+      new LibFMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data
+    = "1 1:1:1 1:2:-1\n0 1:1:-1 2:2:1\n1 2:1:-1 1:2:-1\n0 2:1:1 2:2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 2U);
+
+  const std::vector<unsigned> expected_field{0, 0, 0, 1, 1, 0, 1, 1};
+  const std::vector<unsigned> expected_index{0, 1, 0, 1, 0, 1, 0, 1};
+    // expect to detect 1-based indexing, since all field/feature id's exceed 0
+  const std::vector<real_t> expected_value{1, -1, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->field == expected_field);
+  CHECK(rctr->index == expected_index);
+  CHECK(rctr->value == expected_value);  // perform element-wise comparsion
+}
+
+TEST(LibFMParser, test_indexing_mode_auto_detect_2) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{{"indexing_mode", "0"}};
+  std::unique_ptr<LibFMParserTest<unsigned>> parser(
+      new LibFMParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned>* rctr = new RowBlockContainer<unsigned>();
+  std::string data
+    = "1 1:1:1 1:2:-1\n0 0:0:-2 1:1:-1 2:2:1\n1 2:1:-1 1:2:-1\n0 2:1:1 2:2:1\n";
+  char* out_data = const_cast<char*>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+
+  size_t num_row, num_col;
+  CountDimensions(rctr, &num_row, &num_col);
+  CHECK_EQ(num_row, 4U);
+  CHECK_EQ(num_col, 3U);
+
+  const std::vector<unsigned> expected_field{1, 1, 0, 1, 2, 2, 1, 2, 2};
+  const std::vector<unsigned> expected_index{1, 2, 0, 1, 2, 1, 2, 1, 2};
+    // expect to detect 0-based indexing, since second row has feature id 0
+  const std::vector<real_t> expected_value{1, -1, -2, -1, 1, -1, -1, 1, 1};
+  CHECK(rctr->field == expected_field);
+  CHECK(rctr->index == expected_index);
+  CHECK(rctr->value == expected_value);  // perform element-wise comparsion
 }


### PR DESCRIPTION
Currently the LibSVM and LibFM parsers assume 0-based indexing. However, many LibSVM files in the wild use 1-based indexing. (In fact, the [original LIBSVM implementation](https://github.com/cjlin1/libsvm/blob/master/README) uses 1-based indexing.) This PR adds a new option `indexing_mode` to both parsers to enable 1-based indexing.

Description (EDITED):
* `indexing_mode>0`: use 1-based indexing.
* `indexing_mode=0`: use 0-based indexing
* `indexing_mode<0`: use heuristic to decide between the two modes of indexing. When the smallest feature index is 1 or greater, 1-based indexing is chosen.

For examples, see the unit tests in `test/unittest/unittest_parser.cc`.

Note. Backward compatibility is preserved as follows: when `indexing_mode` is not specified, 0-based indexing is assumed.