### PR TITLE
[IO] Enable endian aware serialization

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -117,6 +117,13 @@
 #endif
 #endif
 
+/*!
+ * \brief Use little endian for binary serialization
+ *  if this is set to 0, use big endian.
+ */
+#ifndef DMLC_IO_USE_LITTLE_ENDIAN
+#define DMLC_IO_USE_LITTLE_ENDIAN 1
+#endif
 
 /*!
  * \brief Enable std::thread related modules,

--- a/include/dmlc/endian.h
+++ b/include/dmlc/endian.h
@@ -1,10 +1,12 @@
 /*!
  *  Copyright (c) 2017 by Contributors
  * \file endian.h
- * \brief Endian testing
+ * \brief Endian testing, need c++11
  */
 #ifndef DMLC_ENDIAN_H_
 #define DMLC_ENDIAN_H_
+
+#include "./base.h"
 
 #if defined(__APPLE__) || defined(_WIN32)
 #define DMLC_LITTLE_ENDIAN 1
@@ -13,5 +15,30 @@
 #define DMLC_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
 #endif
 
+/*! \brief whether serialize using little endian */
+#define DMLC_IO_NO_ENDIAN_SWAP (DMLC_LITTLE_ENDIAN == DMLC_IO_USE_LITTLE_ENDIAN)
+
+namespace dmlc {
+
+/*!
+ * \brief A generic inplace byte swapping function.
+ * \param data The data pointer.
+ * \param elem_bytes The number of bytes of the data elements
+ * \param num_elems Number of elements in the data.
+ * \note Always try pass in constant elem_bytes to enable
+ *       compiler optimization
+ */
+inline void ByteSwap(void* data, size_t elem_bytes, size_t num_elems) {
+  for (size_t i = 0; i < num_elems; ++i) {
+    uint8_t* bptr = reinterpret_cast<uint8_t*>(data) + elem_bytes * i;
+    for (size_t j = 0; j < elem_bytes / 2; ++j) {
+      uint8_t v = bptr[elem_bytes - 1 - j];
+      bptr[elem_bytes - 1 - j] = bptr[j];
+      bptr[j] = v;
+    }
+  }
+}
+
+}  // namespace dmlc
 #endif  // DMLC_ENDIAN_H_
 

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -98,6 +98,7 @@ class Stream {  // NOLINT(*)
    * \param data The data pointer
    * \param num_elems Number of elements
    * \tparam T the data type.
+   * \return whether the load was successful
    */
   template<typename T>
   inline bool ReadArray(T* data, size_t num_elems);

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -58,12 +58,13 @@ class Stream {  // NOLINT(*)
                         bool allow_null = false);
   // helper functions to write/read different data structures
   /*!
-   * \brief writes a data to stream
+   * \brief writes a data to stream.
    *
-   * dmlc::Stream support Write/Read of most STL
-   * composites and base types.
-   * If the data type is not supported, a compile time error will
-   * be issued.
+   * dmlc::Stream support Write/Read of most STL composites and base types.
+   * If the data type is not supported, a compile time error will be issued.
+   *
+   * This function is endian-aware,
+   * the output endian defined by DMLC_IO_USE_LITTLE_ENDIAN
    *
    * \param data data to be written
    * \tparam T the data type to be written
@@ -73,10 +74,11 @@ class Stream {  // NOLINT(*)
   /*!
    * \brief loads a data from stream.
    *
-   * dmlc::Stream support Write/Read of most STL
-   * composites and base types.
-   * If the data type is not supported, a compile time error will
-   * be issued.
+   * dmlc::Stream support Write/Read of most STL composites and base types.
+   * If the data type is not supported, a compile time error will be issued.
+   *
+   * This function is endian-aware,
+   * the input endian defined by DMLC_IO_USE_LITTLE_ENDIAN
    *
    * \param out_data place holder of data to be deserialized
    * \return whether the load was successful

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -85,6 +85,22 @@ class Stream {  // NOLINT(*)
    */
   template<typename T>
   inline bool Read(T *out_data);
+  /*!
+   * \brief Endian aware write array of data.
+   * \param data The data pointer
+   * \param num_elems Number of elements
+   * \tparam T the data type.
+   */
+  template<typename T>
+  inline void WriteArray(const T* data, size_t num_elems);
+  /*!
+   * \brief Endian aware read array of data.
+   * \param data The data pointer
+   * \param num_elems Number of elements
+   * \tparam T the data type.
+   */
+  template<typename T>
+  inline bool ReadArray(T* data, size_t num_elems);
 };
 
 /*! \brief interface of i/o stream that support seek */
@@ -436,6 +452,21 @@ inline void Stream::Write(const T &data) {
 template<typename T>
 inline bool Stream::Read(T *out_data) {
   return serializer::Handler<T>::Read(this, out_data);
+}
+
+template<typename T>
+inline void Stream::WriteArray(const T* data, size_t num_elems) {
+  for (size_t i = 0; i < num_elems; ++i) {
+    this->Write<T>(data[i]);
+  }
+}
+
+template<typename T>
+inline bool Stream::ReadArray(T* data, size_t num_elems) {
+  for (size_t i = 0; i < num_elems; ++i) {
+    if (!this->Read<T>(data + i)) return false;
+  }
+  return true;
 }
 
 #ifndef _LIBCPP_SGX_NO_IOSTREAMS

--- a/include/dmlc/serializer.h
+++ b/include/dmlc/serializer.h
@@ -155,19 +155,14 @@ struct ComposeVectorHandler {
   inline static void Write(Stream *strm, const std::vector<T> &vec) {
     uint64_t sz = static_cast<uint64_t>(vec.size());
     strm->Write<uint64_t>(sz);
-    for (size_t i = 0; i < vec.size(); ++i) {
-      Handler<T>::Write(strm, vec[i]);
-    }
+    strm->WriteArray(dmlc::BeginPtr(vec), vec.size());
   }
   inline static bool Read(Stream *strm, std::vector<T> *out_vec) {
     uint64_t sz;
     if (!strm->Read<uint64_t>(&sz)) return false;
     size_t size = static_cast<size_t>(sz);
     out_vec->resize(size);
-    for (size_t i = 0; i < size; ++i) {
-      if (!Handler<T>::Read(strm, &(*out_vec)[i])) return false;
-    }
-    return true;
+    return strm->ReadArray(dmlc::BeginPtr(*out_vec), size);
   }
 };
 

--- a/include/dmlc/serializer.h
+++ b/include/dmlc/serializer.h
@@ -19,6 +19,7 @@
 #include "./io.h"
 #include "./logging.h"
 #include "./type_traits.h"
+#include "./endian.h"
 
 #if DMLC_USE_CXX11
 #include <unordered_map>
@@ -31,6 +32,7 @@ namespace serializer {
 /*!
  * \brief generic serialization handler
  * \tparam T the type to be serialized
+ * \tparam need_endian_swap Whether use little endian
  */
 template<typename T>
 struct Handler;
@@ -67,12 +69,33 @@ struct IfThenElse<false, Then, Else, T> {
 
 /*! \brief Serializer for POD(plain-old-data) data */
 template<typename T>
-struct PODHandler {
+struct NativePODHandler {
   inline static void Write(Stream *strm, const T &data) {
     strm->Write(&data, sizeof(T));
   }
   inline static bool Read(Stream *strm, T *dptr) {
     return strm->Read((void*)dptr, sizeof(T)) == sizeof(T);  // NOLINT(*)
+  }
+};
+
+/*! \brief Serializer for arithmetic data, handle endianness */
+template<typename T>
+struct ArithmeticHandler {
+  inline static void Write(Stream *strm, const T &data) {
+    if (DMLC_IO_NO_ENDIAN_SWAP) {
+      strm->Write(&data, sizeof(T));
+    } else {
+      T copy = data;
+      ByteSwap(&copy, sizeof(T), 1);
+      strm->Write(&copy, sizeof(T));
+    }
+  }
+  inline static bool Read(Stream *strm, T *dptr) {
+    bool ret = strm->Read((void*)dptr, sizeof(T)) == sizeof(T);  // NOLINT(*)
+    if (!DMLC_IO_NO_ENDIAN_SWAP) {
+      ByteSwap(dptr, sizeof(T), 1);
+    }
+    return ret;
   }
 };
 
@@ -102,17 +125,17 @@ struct UndefinedSerializerFor {
  * \tparam T element type
  */
 template<typename T>
-struct PODVectorHandler {
+struct NativePODVectorHandler {
   inline static void Write(Stream *strm, const std::vector<T> &vec) {
     uint64_t sz = static_cast<uint64_t>(vec.size());
-    strm->Write(&sz, sizeof(sz));
+    strm->Write<uint64_t>(sz);
     if (sz != 0) {
       strm->Write(&vec[0], sizeof(T) * vec.size());
     }
   }
   inline static bool Read(Stream *strm, std::vector<T> *out_vec) {
     uint64_t sz;
-    if (strm->Read(&sz, sizeof(sz)) != sizeof(sz)) return false;
+    if (!strm->Read<uint64_t>(&sz)) return false;
     size_t size = static_cast<size_t>(sz);
     out_vec->resize(size);
     if (sz != 0) {
@@ -131,14 +154,14 @@ template<typename T>
 struct ComposeVectorHandler {
   inline static void Write(Stream *strm, const std::vector<T> &vec) {
     uint64_t sz = static_cast<uint64_t>(vec.size());
-    strm->Write(&sz, sizeof(sz));
+    strm->Write<uint64_t>(sz);
     for (size_t i = 0; i < vec.size(); ++i) {
       Handler<T>::Write(strm, vec[i]);
     }
   }
   inline static bool Read(Stream *strm, std::vector<T> *out_vec) {
     uint64_t sz;
-    if (strm->Read(&sz, sizeof(sz)) != sizeof(sz)) return false;
+    if (!strm->Read<uint64_t>(&sz)) return false;
     size_t size = static_cast<size_t>(sz);
     out_vec->resize(size);
     for (size_t i = 0; i < size; ++i) {
@@ -153,17 +176,17 @@ struct ComposeVectorHandler {
  * \tparam T element type
  */
 template<typename T>
-struct PODStringHandler {
+struct NativePODStringHandler {
   inline static void Write(Stream *strm, const std::basic_string<T> &vec) {
     uint64_t sz = static_cast<uint64_t>(vec.length());
-    strm->Write(&sz, sizeof(sz));
+    strm->Write<uint64_t>(sz);
     if (sz != 0) {
       strm->Write(&vec[0], sizeof(T) * vec.length());
     }
   }
   inline static bool Read(Stream *strm, std::basic_string<T> *out_vec) {
     uint64_t sz;
-    if (strm->Read(&sz, sizeof(sz)) != sizeof(sz)) return false;
+    if (!strm->Read<uint64_t>(&sz)) return false;
     size_t size = static_cast<size_t>(sz);
     out_vec->resize(size);
     if (sz != 0) {
@@ -245,11 +268,14 @@ struct Handler {
    * \param data the data obeject to be serialized
    */
   inline static void Write(Stream *strm, const T &data) {
-    IfThenElse<dmlc::is_pod<T>::value,
-               PODHandler<T>,
-               IfThenElse<dmlc::has_saveload<T>::value,
-                          SaveLoadClassHandler<T>,
-                          UndefinedSerializerFor<T>, T>,
+    IfThenElse<dmlc::is_arithmetic<T>::value,
+               ArithmeticHandler<T>,
+               IfThenElse<dmlc::is_pod<T>::value && DMLC_IO_NO_ENDIAN_SWAP,
+                          NativePODHandler<T>,
+                          IfThenElse<dmlc::has_saveload<T>::value,
+                                     SaveLoadClassHandler<T>,
+                                     UndefinedSerializerFor<T>, T>,
+                          T>,
                T>
         ::Write(strm, data);
   }
@@ -260,12 +286,16 @@ struct Handler {
    * \return whether the read is successful
    */
   inline static bool Read(Stream *strm, T *data) {
-    return IfThenElse<dmlc::is_pod<T>::value,
-                      PODHandler<T>,
-                      IfThenElse<dmlc::has_saveload<T>::value,
-                                 SaveLoadClassHandler<T>,
-                                 UndefinedSerializerFor<T>, T>,
-                      T>
+    return
+    IfThenElse<dmlc::is_arithmetic<T>::value,
+               ArithmeticHandler<T>,
+               IfThenElse<dmlc::is_pod<T>::value && DMLC_IO_NO_ENDIAN_SWAP,
+                          NativePODHandler<T>,
+                          IfThenElse<dmlc::has_saveload<T>::value,
+                                     SaveLoadClassHandler<T>,
+                                     UndefinedSerializerFor<T>, T>,
+                          T>,
+               T>
     ::Read(strm, data);
   }
 };
@@ -274,14 +304,14 @@ struct Handler {
 template<typename T>
 struct Handler<std::vector<T> > {
   inline static void Write(Stream *strm, const std::vector<T> &data) {
-    IfThenElse<dmlc::is_pod<T>::value,
-               PODVectorHandler<T>,
+    IfThenElse<dmlc::is_pod<T>::value && DMLC_IO_NO_ENDIAN_SWAP,
+               NativePODVectorHandler<T>,
                ComposeVectorHandler<T>, std::vector<T> >
     ::Write(strm, data);
   }
   inline static bool Read(Stream *strm, std::vector<T> *data) {
-    return IfThenElse<dmlc::is_pod<T>::value,
-                      PODVectorHandler<T>,
+    return IfThenElse<dmlc::is_pod<T>::value && DMLC_IO_NO_ENDIAN_SWAP,
+                      NativePODVectorHandler<T>,
                       ComposeVectorHandler<T>,
                       std::vector<T> >
     ::Read(strm, data);
@@ -291,15 +321,15 @@ struct Handler<std::vector<T> > {
 template<typename T>
 struct Handler<std::basic_string<T> > {
   inline static void Write(Stream *strm, const std::basic_string<T> &data) {
-    IfThenElse<dmlc::is_pod<T>::value,
-               PODStringHandler<T>,
+    IfThenElse<dmlc::is_pod<T>::value && (DMLC_IO_NO_ENDIAN_SWAP || sizeof(T) == 1),
+               NativePODStringHandler<T>,
                UndefinedSerializerFor<T>,
                std::basic_string<T> >
     ::Write(strm, data);
   }
   inline static bool Read(Stream *strm, std::basic_string<T> *data) {
-    return IfThenElse<dmlc::is_pod<T>::value,
-                      PODStringHandler<T>,
+    return IfThenElse<dmlc::is_pod<T>::value && (DMLC_IO_NO_ENDIAN_SWAP || sizeof(T) == 1),
+                      NativePODStringHandler<T>,
                       UndefinedSerializerFor<T>,
                       std::basic_string<T> >
     ::Read(strm, data);
@@ -309,15 +339,19 @@ struct Handler<std::basic_string<T> > {
 template<typename TA, typename TB>
 struct Handler<std::pair<TA, TB> > {
   inline static void Write(Stream *strm, const std::pair<TA, TB> &data) {
-    IfThenElse<dmlc::is_pod<TA>::value && dmlc::is_pod<TB>::value,
-               PODHandler<std::pair<TA, TB> >,
+    IfThenElse<dmlc::is_pod<TA>::value &&
+               dmlc::is_pod<TB>::value &&
+               DMLC_IO_NO_ENDIAN_SWAP,
+               NativePODHandler<std::pair<TA, TB> >,
                PairHandler<TA, TB>,
                std::pair<TA, TB> >
     ::Write(strm, data);
   }
   inline static bool Read(Stream *strm, std::pair<TA, TB> *data) {
-    return IfThenElse<dmlc::is_pod<TA>::value && dmlc::is_pod<TB>::value,
-                      PODHandler<std::pair<TA, TB> >,
+    return IfThenElse<dmlc::is_pod<TA>::value &&
+                      dmlc::is_pod<TB>::value &&
+                      DMLC_IO_NO_ENDIAN_SWAP,
+                      NativePODHandler<std::pair<TA, TB> >,
                       PairHandler<TA, TB>,
                       std::pair<TA, TB> >
     ::Read(strm, data);

--- a/test/unittest/unittest_serializer.cc
+++ b/test/unittest/unittest_serializer.cc
@@ -1,3 +1,7 @@
+// test for case where we use big endian serializer
+// this is a harder case
+#define DMLC_IO_USE_LITTLE_ENDIAN 0
+
 #include <dmlc/io.h>
 #include <dmlc/memory_io.h>
 #include <dmlc/logging.h>
@@ -44,18 +48,6 @@ class MyClass {
 // need to declare the traits property of my class to dmlc
 namespace dmlc { DMLC_DECLARE_TRAITS(has_saveload, MyClass, true); }
 
-struct Param {
-  int a;
-  int b;
-  Param() {}
-  Param(int a, int b) : a(a), b(b) {}
-  inline bool operator==(const Param &other) const {
-    return a == other.a && b == other.b;
-  }
-};
-// need to declare the traits property of my class to dmlc
-namespace dmlc { DMLC_DECLARE_TRAITS(is_pod, Param, true); }
-
 // test serializer
 TEST(Serializer, basics) {
   int n = 10;
@@ -82,9 +74,30 @@ TEST(Serializer, basics) {
       std::unordered_multimap<int, std::string>  {{1, "hellkow"}, {1, "world"}, {2, "111"}});
   TestSaveLoad(std::set<std::string>  {"hjhjm", "asasa"});
   TestSaveLoad(std::unordered_set<std::string>  {"hjhjm", "asasa"});
+  LOG(INFO) << "jere";
   TestSaveLoad(std::list<std::string>  {"hjhjm", "asasa"});
   TestSaveLoad(std::list<int>(a.begin(), a.end()));
   TestSaveLoad(std::list<MyClass> {MyClass("abc"), MyClass("def")});
-  TestSaveLoad(std::list<Param> {Param(3, 4), Param(5, 6)});
+}
 
+
+// test serializer
+TEST(Serializer, endian) {
+  int n = 10;
+  std::string blob;
+  dmlc::MemoryStringStream fs(&blob);
+  dmlc::Stream* strm = &fs;
+  strm->Write(n);
+  // big endians
+  if (DMLC_IO_USE_LITTLE_ENDIAN == 0) {
+    ASSERT_EQ(blob[0], 0);
+    ASSERT_EQ(blob[1], 0);
+    ASSERT_EQ(blob[2], 0);
+    ASSERT_EQ(blob[3], 10);
+  } else {
+    ASSERT_EQ(blob[0], 10);
+    ASSERT_EQ(blob[1], 0);
+    ASSERT_EQ(blob[2], 0);
+    ASSERT_EQ(blob[3], 0);
+  }
 }


### PR DESCRIPTION
The original binary serialization is not aware of endianess of the target machine. This patch resolves that by add endian aware serialization and loading. 

Default behavior matches the existing serialization(use little endian) on most of machines we target