### PR TITLE
fix some issues in mpi tracker

### DIFF
--- a/tracker/dmlc_tracker/mpi.py
+++ b/tracker/dmlc_tracker/mpi.py
@@ -21,14 +21,14 @@ def get_mpi_env(envs):
         return cmd
 
     # decide MPI version.
-    (_, err) = subprocess.Popen(['mpirun','--verion'],
+    (out, err) = subprocess.Popen(['mpirun','--version'],
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE).communicate()
     cmd = ''
-    if 'Open MPI' in err:
+    if b'Open MPI' in out:
         for k, v in envs.items():
             cmd += ' -x %s=%s' % (k, str(v))
-    elif 'mpich' in err:
+    elif b'mpich' in err:
         for k, v in envs.items():
             cmd += ' -env %s %s' % (k, str(v))
     else:


### PR DESCRIPTION
fix the typo for mpirun --version
for openmpi:
the version info is no longer in stderr but stdout
convert from str to bytes for python3