### PR TITLE
Don't define DMLC_LOG_STACK_TRACE on Solaris

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -42,6 +42,7 @@
  * enabled on linux when using gcc.
  */
 #if (defined(__GNUC__) && !defined(__MINGW32__)\
+     && !defined(__sun) && !defined(__SVR4)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))
 #if (!defined(DMLC_LOG_STACK_TRACE))
 #define DMLC_LOG_STACK_TRACE 1


### PR DESCRIPTION
DMLC_LOG_STACK_TRACE involves use of non-standard header execinfo.h, which causes compilation failure on Solaris.