### PR TITLE
add parameter delimiter type for CSV parser

### DIFF
--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -22,12 +22,15 @@ namespace data {
 struct CSVParserParam : public Parameter<CSVParserParam> {
   std::string format;
   int label_column;
+  std::string delimiter;
   // declare parameters
   DMLC_DECLARE_PARAMETER(CSVParserParam) {
     DMLC_DECLARE_FIELD(format).set_default("csv")
         .describe("File format.");
     DMLC_DECLARE_FIELD(label_column).set_default(-1)
         .describe("Column index that will put into label.");
+    DMLC_DECLARE_FIELD(delimiter).set_default(",")
+      .describe("Delimiter used in the csv file.");
   }
 };
 
@@ -106,7 +109,12 @@ ParseBlock(const char *begin,
         out->index.push_back(idx++);
       }
       ++column_index;
-      while (*p != ',' && p != lend) ++p;
+      while (*p != param_.delimiter[0] && p != lend) ++p;
+      if (p == lend && idx == 0) {
+        LOG(FATAL) << "Delimiter \'" << param_.delimiter << "\' is not found in the line. "
+                   << "Expected \'" << param_.delimiter
+                   << "\' as the delimiter to separate fields.";
+      }
       if (p != lend) ++p;
     }
     // skip empty line

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -135,6 +135,21 @@ TEST(CSVParser, test_noeol) {
   }
 }
 
+TEST(CSVParser, test_delimiter) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args{ {"delimiter", " "} };
+  std::unique_ptr<CSVParserTest<unsigned>> parser(
+      new CSVParserTest<unsigned>(source, args, 1));
+  RowBlockContainer<unsigned> *rctr = new RowBlockContainer<unsigned>();
+  std::string data = "0 1 2 3\n4 5 6 7\n8 9 10 11";
+  char *out_data = const_cast<char *>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+  for (size_t i = 0; i < rctr->value.size(); i++) {
+    CHECK(i == rctr->value[i]);
+  }
+}
+
 TEST(LibSVMParser, test_qid) {
   using namespace parser_test;
   InputSplit *source = nullptr;


### PR DESCRIPTION
Add 'delimiter' type in CSV parameters. This can be further improved in the python frontend to enable users specify delimiter type in the CSV input. If users don't specify, by default it used ',' as the delimiter.