### PR TITLE
Add support for int64 for CSVParser

### DIFF
--- a/src/data.cc
+++ b/src/data.cc
@@ -129,21 +129,39 @@ RowBlockIter<uint64_t, real_t>::Create(const char *uri,
 }
 
 template<>
-RowBlockIter<uint32_t, int> *
-RowBlockIter<uint32_t, int>::Create(const char *uri,
+RowBlockIter<uint32_t, int32_t> *
+RowBlockIter<uint32_t, int32_t>::Create(const char *uri,
                                     unsigned part_index,
                                     unsigned num_parts,
                                     const char *type) {
-  return data::CreateIter_<uint32_t, int>(uri, part_index, num_parts, type);
+  return data::CreateIter_<uint32_t, int32_t>(uri, part_index, num_parts, type);
 }
 
 template<>
-RowBlockIter<uint64_t, int> *
-RowBlockIter<uint64_t, int>::Create(const char *uri,
+RowBlockIter<uint64_t, int32_t> *
+RowBlockIter<uint64_t, int32_t>::Create(const char *uri,
                                     unsigned part_index,
                                     unsigned num_parts,
                                     const char *type) {
-  return data::CreateIter_<uint64_t, int>(uri, part_index, num_parts, type);
+  return data::CreateIter_<uint64_t, int32_t>(uri, part_index, num_parts, type);
+}
+
+template<>
+RowBlockIter<uint32_t, int64_t> *
+RowBlockIter<uint32_t, int64_t>::Create(const char *uri,
+                                        unsigned part_index,
+                                        unsigned num_parts,
+                                        const char *type) {
+  return data::CreateIter_<uint32_t, int64_t>(uri, part_index, num_parts, type);
+}
+
+template<>
+RowBlockIter<uint64_t, int64_t> *
+RowBlockIter<uint64_t, int64_t>::Create(const char *uri,
+                                        unsigned part_index,
+                                        unsigned num_parts,
+                                        const char *type) {
+  return data::CreateIter_<uint64_t, int64_t>(uri, part_index, num_parts, type);
 }
 
 template<>
@@ -165,32 +183,54 @@ Parser<uint64_t, real_t>::Create(const char *uri_,
 }
 
 template<>
-Parser<uint32_t, int> *
-Parser<uint32_t, int>::Create(const char *uri_,
+Parser<uint32_t, int32_t> *
+Parser<uint32_t, int32_t>::Create(const char *uri_,
                               unsigned part_index,
                               unsigned num_parts,
                               const char *type) {
-  return data::CreateParser_<uint32_t, int>(uri_, part_index, num_parts, type);
+  return data::CreateParser_<uint32_t, int32_t>(uri_, part_index, num_parts, type);
 }
 
 template<>
-Parser<uint64_t, int> *
-Parser<uint64_t, int>::Create(const char *uri_,
+Parser<uint64_t, int32_t> *
+Parser<uint64_t, int32_t>::Create(const char *uri_,
                               unsigned part_index,
                               unsigned num_parts,
                               const char *type) {
-  return data::CreateParser_<uint64_t, int>(uri_, part_index, num_parts, type);
+  return data::CreateParser_<uint64_t, int32_t>(uri_, part_index, num_parts, type);
+}
+
+template<>
+Parser<uint32_t, int64_t> *
+Parser<uint32_t, int64_t>::Create(const char *uri_,
+                                  unsigned part_index,
+                                  unsigned num_parts,
+                                  const char *type) {
+  return data::CreateParser_<uint32_t, int64_t>(uri_, part_index, num_parts, type);
+}
+
+template<>
+Parser<uint64_t, int64_t> *
+Parser<uint64_t, int64_t>::Create(const char *uri_,
+                                  unsigned part_index,
+                                  unsigned num_parts,
+                                  const char *type) {
+  return data::CreateParser_<uint64_t, int64_t>(uri_, part_index, num_parts, type);
 }
 
 // registry
 typedef ParserFactoryReg<uint32_t, real_t> Reg32flt;
-typedef ParserFactoryReg<uint32_t, int> Reg32int;
+typedef ParserFactoryReg<uint32_t, int32_t> Reg32int;
+typedef ParserFactoryReg<uint32_t, int64_t> Reg32int64;
 typedef ParserFactoryReg<uint64_t, real_t> Reg64flt;
-typedef ParserFactoryReg<uint64_t, int> Reg64int;
+typedef ParserFactoryReg<uint64_t, int32_t> Reg64int;
+typedef ParserFactoryReg<uint64_t, int64_t> Reg64int64;
 DMLC_REGISTRY_ENABLE(Reg32flt);
 DMLC_REGISTRY_ENABLE(Reg32int);
+DMLC_REGISTRY_ENABLE(Reg32int64);
 DMLC_REGISTRY_ENABLE(Reg64flt);
 DMLC_REGISTRY_ENABLE(Reg64int);
+DMLC_REGISTRY_ENABLE(Reg64int64);
 
 DMLC_REGISTER_DATA_PARSER(
   uint32_t, real_t, libsvm, data::CreateLibSVMParser<uint32_t __DMLC_COMMA real_t>);
@@ -204,7 +244,13 @@ DMLC_REGISTER_DATA_PARSER(
   uint32_t, real_t, csv, data::CreateCSVParser<uint32_t __DMLC_COMMA real_t>);
 DMLC_REGISTER_DATA_PARSER(
   uint64_t, real_t, csv, data::CreateCSVParser<uint64_t __DMLC_COMMA real_t>);
-DMLC_REGISTER_DATA_PARSER(uint32_t, int, csv, data::CreateCSVParser<uint32_t __DMLC_COMMA int>);
-DMLC_REGISTER_DATA_PARSER(uint64_t, int, csv, data::CreateCSVParser<uint64_t __DMLC_COMMA int>);
+DMLC_REGISTER_DATA_PARSER(
+  uint32_t, int32_t, csv, data::CreateCSVParser<uint32_t __DMLC_COMMA int32_t>);
+DMLC_REGISTER_DATA_PARSER(
+  uint64_t, int32_t, csv, data::CreateCSVParser<uint64_t __DMLC_COMMA int32_t>);
+DMLC_REGISTER_DATA_PARSER(
+  uint32_t, int64_t, csv, data::CreateCSVParser<uint32_t __DMLC_COMMA int64_t>);
+DMLC_REGISTER_DATA_PARSER(
+  uint64_t, int64_t, csv, data::CreateCSVParser<uint64_t __DMLC_COMMA int64_t>);
 
 }  // namespace dmlc

--- a/src/data.cc
+++ b/src/data.cc
@@ -220,16 +220,16 @@ Parser<uint64_t, int64_t>::Create(const char *uri_,
 
 // registry
 typedef ParserFactoryReg<uint32_t, real_t> Reg32flt;
-typedef ParserFactoryReg<uint32_t, int32_t> Reg32int;
+typedef ParserFactoryReg<uint32_t, int32_t> Reg32int32;
 typedef ParserFactoryReg<uint32_t, int64_t> Reg32int64;
 typedef ParserFactoryReg<uint64_t, real_t> Reg64flt;
-typedef ParserFactoryReg<uint64_t, int32_t> Reg64int;
+typedef ParserFactoryReg<uint64_t, int32_t> Reg64int32;
 typedef ParserFactoryReg<uint64_t, int64_t> Reg64int64;
 DMLC_REGISTRY_ENABLE(Reg32flt);
-DMLC_REGISTRY_ENABLE(Reg32int);
+DMLC_REGISTRY_ENABLE(Reg32int32);
 DMLC_REGISTRY_ENABLE(Reg32int64);
 DMLC_REGISTRY_ENABLE(Reg64flt);
-DMLC_REGISTRY_ENABLE(Reg64int);
+DMLC_REGISTRY_ENABLE(Reg64int32);
 DMLC_REGISTRY_ENABLE(Reg64int64);
 
 DMLC_REGISTER_DATA_PARSER(

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -88,11 +88,14 @@ ParseBlock(const char *begin,
       if (std::is_same<DType, real_t>::value) {
         v = strtof(p, &endptr);
       // If DType is int32
-      } else if (std::is_same<DType, int>::value) {
-        v = static_cast<int>(strtol(p, &endptr, 0));
+      } else if (std::is_same<DType, int32_t>::value) {
+        v = static_cast<int32_t>(strtol(p, &endptr, 0));
+      // If DType is int64
+      } else if (std::is_same<DType, int64_t>::value) {
+        v = static_cast<int64_t>(strtol(p, &endptr, 0));
       // If DType is all other types
       } else {
-        LOG(FATAL) << "Only float32 and int32 are supported for the time being";
+        LOG(FATAL) << "Only float32, int32, and int64 are supported for the time being";
       }
       p = (endptr >= lend) ? lend : endptr;
 

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -59,13 +59,13 @@ TEST(CSVParser, test_standard_case) {
   }
 }
 
-TEST(CSVParser, test_integer_parse) {
+TEST(CSVParser, test_int32_parse) {
   using namespace parser_test;
   InputSplit *source = nullptr;
   const std::map<std::string, std::string> args;
-  std::unique_ptr<CSVParserTest<unsigned, int>> parser(
-      new CSVParserTest<unsigned, int>(source, args, 1));
-  RowBlockContainer<unsigned, int> *rctr = new RowBlockContainer<unsigned, int>();
+  std::unique_ptr<CSVParserTest<unsigned, int32_t>> parser(
+      new CSVParserTest<unsigned, int32_t>(source, args, 1));
+  RowBlockContainer<unsigned, int32_t> *rctr = new RowBlockContainer<unsigned, int32_t>();
   std::string data = "20000000,20000001,20000002,20000003\n"
                      "20000004,20000005,20000006,20000007\n"
                      "20000008,20000009,20000010,20000011\n";
@@ -73,6 +73,23 @@ TEST(CSVParser, test_integer_parse) {
   parser->CallParseBlock(out_data, out_data + data.size(), rctr);
   for (size_t i = 0; i < rctr->value.size(); i++) {
     CHECK((i+20000000) == rctr->value[i]);
+  }
+}
+
+TEST(CSVParser, test_int64_parse) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
+  std::unique_ptr<CSVParserTest<unsigned, int64_t>> parser(
+    new CSVParserTest<unsigned, int64_t>(source, args, 1));
+  RowBlockContainer<unsigned, int64_t> *rctr = new RowBlockContainer<unsigned, int64_t>();
+  std::string data = "2147483648,2147483649,2147483650,2147483651\n"
+                     "2147483652,2147483653,2147483654,2147483655\n"
+                     "2147483656,2147483657,2147483658,2147483659\n";
+  char *out_data = const_cast<char *>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr);
+  for (size_t i = 0; i < rctr->value.size(); i++) {
+    CHECK((i+2147483648) == rctr->value[i]);
   }
 }
 


### PR DESCRIPTION
Same as title.
This PR adds support for parsing int64 data type in dmlc-core, so that mxnet could also support this type in CSVIter