### PR TITLE
Fix incorrect pointer arithmetic for handling qid format

### DIFF
--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -67,11 +67,11 @@ ParseBlock(const char *begin,
     uint64_t qid;
     p = q;
     while (p != end && *p == ' ') ++p;
-    if (p != lend && (strncmp(p, "qid:", 4) == 0))  {
+    if (p != lend && (strncmp(p, "qid:", 4) == 0)) {
       p += 4;
-      qid = atoll(p);
+      qid = static_cast<uint64_t>(atoll(p));
+      while (p != lend && isdigitchars(*p)) ++p;
       out->qid.push_back(qid);
-      p = q;
     }
     // parse feature[:value]
     while (p != lend) {


### PR DESCRIPTION
This is a follow-up of #317. Due to an incorrect pointer arithmetic, the query-id (qid) information in each row was also being inserted into the `offset` array. To re-produce the problem, run the `LibSVMParser.test_qid` test without the bug fix.