### PR TITLE
fix bug in read s3 data with shuffle_chunck_size

### DIFF
--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -175,6 +175,9 @@ void InputSplitBase::InitInputFileInfo(const std::string& uri,
 }
 
 size_t InputSplitBase::Read(void *ptr, size_t size) {
+  if (fs_ == NULL) {
+    return 0;
+  }
   if (offset_begin_ >= offset_end_) return 0;
   if (offset_curr_ +  size > offset_end_) {
     // allow for extra newlines between files


### PR DESCRIPTION
When we use shuffle_chunck_size > 0 in mx.io.shuffle_chunck_size to read rec data saved on s3, 'fs_' is usually empty in read func.
Can we add this judgment, return 0 when fs_ is null.
@tqchen 