### PR TITLE
Provide the failing command in RuntimeError()

### DIFF
--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -41,7 +41,7 @@ def exec_cmd(cmd, role, taskid, pass_env):
             if os.name == 'nt':
                 sys.exit(-1)
             else:
-                raise RuntimeError('Get nonzero return code=%d' % ret)
+                raise RuntimeError('Get nonzero return code=%d on %s %s' % (ret, cmd, env))
 
 
 def submit(args):


### PR DESCRIPTION
When raising a RuntimeError(), provide the failing command and its parameters to speed up debugging.