### PR TITLE
Initialize cmd before using it

### DIFF
--- a/tracker/dmlc_tracker/mpi.py
+++ b/tracker/dmlc_tracker/mpi.py
@@ -15,6 +15,7 @@ def get_mpi_env(envs):
     """
 
     # windows hack: we will use msmpi
+    cmd = ''
     if sys.platform == 'win32':
         for k, v in envs.items():
             cmd += ' -env %s %s' % (k, str(v))


### PR DESCRIPTION
Without this change NameError might be raised at runtime.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tracker/dmlc_tracker/mpi.py:20:13: F821 undefined name 'cmd'
            cmd += ' -env %s %s' % (k, str(v))
            ^
./tracker/dmlc_tracker/slurm.py:33:26: E999 TabError: inconsistent use of tabs and spaces in indentation
	  nworker_nodes = nworker
                         ^
1     E999 TabError: inconsistent use of tabs and spaces in indentation
1     F821 undefined name 'cmd'
2
```