### PR TITLE
[MXNET-686] Fix 'make lint' error in Python2 environment

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # pylint: disable=protected-access, unused-variable, locally-disabled, len-as-condition
 """Lint helper to generate lint summary of source.
 


### PR DESCRIPTION
Fix the issue in https://github.com/apache/incubator-mxnet/issues/11224
Tested in both Python2 and Python3 environment