### PR TITLE
fix bug when use path_imgidx in ImageRecordIter

### DIFF
--- a/src/io/indexed_recordio_split.cc
+++ b/src/io/indexed_recordio_split.cc
@@ -46,8 +46,8 @@ void IndexedRecordIOSplitter::ReadIndexFile(FileSystem *fs, const std::string& i
     << "IndexedRecordIOSplitter does not support multiple index files";
   for (size_t i = 0; i < expanded_list.size(); ++i) {
     const URI& path = expanded_list[i];
-    dmlc::Stream *file_stream = fs->Open(path, "r", true);
-    dmlc::istream index_file(file_stream);
+    std::unique_ptr<dmlc::Stream> file_stream(fs->Open(path, "r", true));
+    dmlc::istream index_file(file_stream.get());
     std::vector<size_t> temp;
     size_t index, offset;
     while (index_file >> index >> offset) {

--- a/src/io/indexed_recordio_split.cc
+++ b/src/io/indexed_recordio_split.cc
@@ -46,7 +46,8 @@ void IndexedRecordIOSplitter::ReadIndexFile(FileSystem *fs, const std::string& i
     << "IndexedRecordIOSplitter does not support multiple index files";
   for (size_t i = 0; i < expanded_list.size(); ++i) {
     const URI& path = expanded_list[i];
-    std::ifstream index_file(path.str());
+    dmlc::Stream *file_stream = fs->Open(path, "r", true);
+    dmlc::istream index_file(file_stream);
     std::vector<size_t> temp;
     size_t index, offset;
     while (index_file >> index >> offset) {


### PR DESCRIPTION
When use ImageRecordIter read data set on S3, use std::ifstream to read idx file on S3 will cause segment fault.
Can we change it to dmlc::Stream created by fs->Open.
@tqchen 