### PR TITLE
add error message for s3 list

### DIFF
--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1070,6 +1070,8 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
     if (!s3_session_token_.empty()) {
       slist = curl_slist_append(slist, stoken.str().c_str());
     }
+    char errbuf[CURL_ERROR_SIZE];
+    CHECK(curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, &errbuf) == CURLE_OK);
     CHECK(curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist) == CURLE_OK);
     CHECK(curl_easy_setopt(curl, CURLOPT_URL, surl.str().c_str()) == CURLE_OK);
     CHECK(curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L) == CURLE_OK);
@@ -1080,7 +1082,7 @@ void S3FileSystem::ListObjects(const URI &path, std::vector<FileInfo> *out_list)
       CHECK(curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L) == CURLE_OK);
       CHECK(curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L) == CURLE_OK);
     }
-    CHECK(curl_easy_perform(curl) == CURLE_OK);
+    CHECK(curl_easy_perform(curl) == CURLE_OK) << "Error: " << errbuf;
     curl_slist_free_all(slist);
     curl_easy_cleanup(curl);
 


### PR DESCRIPTION
previously the check doesn't include any error message regarding failure. I'm using [CURLOPT_ERRORBUFFER](https://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html) as recommended by curl.