### PR TITLE
fix bug in reading overlapped data in the distributed mode

### DIFF
--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -226,7 +226,7 @@ bool InputSplitBase::ReadChunk(void *buf, size_t *size) {
                             max_size - olen);
   nread += olen;
   if (nread == 0) return false;
-  if (nread == olen) { // add extra newline to handle files with NOEOL
+  if (nread == olen) {  // add extra newline to handle files with NOEOL
     char *bufptr = reinterpret_cast<char*>(buf);
     bufptr[nread] = '\n';
     nread++;

--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -226,6 +226,11 @@ bool InputSplitBase::ReadChunk(void *buf, size_t *size) {
                             max_size - olen);
   nread += olen;
   if (nread == 0) return false;
+  if (nread == olen) { // add extra newline to handle files with NOEOL
+    char *bufptr = reinterpret_cast<char*>(buf);
+    bufptr[nread] = '\n';
+    nread++;
+  }
 
   const char *bptr = reinterpret_cast<const char*>(buf);
   // return the last position where a record starts

--- a/test/unittest/unittest_inputsplit.cc
+++ b/test/unittest/unittest_inputsplit.cc
@@ -184,3 +184,45 @@ TEST(InputSplit, test_split_libsvm) {
   ASSERT_EQ(num_row, 5U);
   ASSERT_EQ(num_col, 125U);
 }
+
+TEST(InputSplit, test_split_libsvm_distributed) {
+  {
+    /* Create a test case for partitioned libsvm */
+    TemporaryDirectory tempdir;
+    const char* line
+      = "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
+        "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1\n";
+    const int nfile = 5;
+    for (int file_id = 0; file_id < nfile; ++file_id) {
+      std::string filename
+        = tempdir.path + "/test_" + std::to_string(file_id) + ".libsvm";
+      std::ofstream of(filename.c_str(), std::ios::binary);
+      const int nrepeat = (file_id == 0 ? 6 : 1);
+      for (int i = 0; i < nrepeat; ++i) {
+        of << line;
+      }
+    }
+
+    /* Load the test case with InputSplit and obtain matrix dimensions */
+    const int npart = 2;
+    const size_t expected_dims[npart][2] = { {6, 125}, {4, 125} };
+    for (int part_id = 0; part_id < npart; ++part_id) {
+      std::unique_ptr<dmlc::Parser<uint32_t> > parser(
+        dmlc::Parser<uint32_t>::Create(tempdir.path.c_str(), part_id, npart, "libsvm"));
+      size_t num_row, num_col;
+      CountDimensions(parser.get(), &num_row, &num_col);
+      ASSERT_EQ(num_row, expected_dims[part_id][0]);
+      ASSERT_EQ(num_col, expected_dims[part_id][1]);
+    }
+
+    /* Clean up */
+    for (int file_id = 0; file_id < nfile; ++file_id) {
+      std::string filename
+        = tempdir.path + "/test_" + std::to_string(file_id) + ".libsvm";
+      if (std::remove(filename.c_str()) != 0) {
+        std::cerr << "Couldn't remove file " << filename << std::endl;
+        exit(-1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
I encounter an error when using the distributed XGBoost(see here for detail https://discuss.xgboost.ai/t/errors-in-distributed-training/186). 
The reason is caused by the reading and parsing data logic here instead of the data itself. 
It happened when reading the last chunk in a worker. The detail is that we reserve extra newlines between remaining files but these spaces may be used to read overlapped data which should be handle in next worker. In this case, offset_curr_ will be greater than offset_end_ and it will bypass the FindLastRecordBegin which could correct the boundary. 
One of the debug log I have printed for it is shown that the end lines of data in ParseBlock(libsvm_parser.cc) is incomplete.
e.g. "1.0 1:0 2.0 .....  1113:0.0 1114:0.0 1115:0.0 1116:0.0 \n 1.0 1"
And it would check failed when the last feature contains key only.

Besides, the previous code also has risk of ArrayIndexOutOfBounds Exception since we add num_extra_eol to the  size(https://github.com/dmlc/dmlc-core/blob/master/src/io/input_split_base.cc#L185) and it may exceed the length of Chunk if we have too many files left.
