### PR TITLE
Fix #457: fopen64 macro shouldn't override content of stdio.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,13 @@ matrix:
   - env: TASK=unittest_gtest
     os: linux
     python: '3.6'
+  - env: TASK=cmake_test
+    os: linux
+    python: '3.6'
   - env: TASK=unittest_gtest
+    language: ruby
+    os: osx
+  - env: TASK=cmake_test
     language: ruby
     os: osx
 

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -190,9 +190,6 @@
 #endif
 #endif
 
-#include <dmlc/build_config.h>
-
-
 extern "C" {
 #include <sys/types.h>
 }
@@ -281,5 +278,10 @@ inline const char* BeginPtr(const std::string &str) {
 #define constexpr const
 #define alignof __alignof
 #endif
+
+/* If fopen64 is not defined by current machine,
+   replace fopen64 with std::fopen. Always keep this #include at the bottom
+   of dmlc/base.h */
+#include <dmlc/build_config.h>
 
 #endif  // DMLC_BASE_H_

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -30,3 +30,22 @@ if [ ${TASK} == "unittest_gtest" ]; then
     make all
     test/unittest/dmlc_unittest
 fi
+
+if [ ${TASK} == "cmake_test" ]; then
+    # Build GTest with CMake
+    wget -nc https://github.com/google/googletest/archive/release-1.7.0.zip
+    unzip -n release-1.7.0.zip
+    mv googletest-release-1.7.0 gtest && cd gtest
+    cmake . && make
+    mkdir lib && mv libgtest.a lib
+    cd ..
+    rm -rf release-1.7.0.zip
+
+    # Build dmlc-core with CMake, including unit tests
+    rm -rf build
+    mkdir build && cd build
+    cmake .. -DGTEST_ROOT=$PWD/../gtest/
+    make
+    cd ..
+    ./build/test/unittest/dmlc_unit_tests
+fi

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,5 +1,7 @@
 # ---[ Google Test
-if(NOT GTEST_ROOT)
+if(GTEST_ROOT)
+    find_package(GTest)
+else()
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest")
         add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/googletest")
         set(GTEST_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/googletest")


### PR DESCRIPTION
Fixes #457.

Diagnosis: The generated header `dmlc/build_config.h` is being `#include`d before `stdio.h`, so the unused declaration of `fopen64` is being replaced with `std::fopen`. The solution is to `#include` the header `dmlc/build_config.h` later so that its macro does not affect the content of `stdio.h`.

Also add CMake builds to CI tests to prevent breaking CMake builds in the future.