### PR TITLE
Fix gtest can not find source build issue

### DIFF
--- a/scripts/packages.mk
+++ b/scripts/packages.mk
@@ -9,7 +9,7 @@ ${CACHE_PREFIX}/include/gtest:
 	wget https://github.com/google/googletest/archive/release-1.7.0.zip
 	unzip release-1.7.0.zip
 	mv googletest-release-1.7.0 gtest
-	cd gtest; g++ -Iinclude -pthread -c src/gtest-all.cc -o gtest-all.o; cd ..
+	cd gtest; g++ -I. -Iinclude -pthread -c src/gtest-all.cc -o gtest-all.o; cd ..
 	ar -rv libgtest.a gtest/gtest-all.o
 	mkdir -p ${CACHE_PREFIX}/include ${CACHE_PREFIX}/lib
 	cp -r gtest/include/gtest ${CACHE_PREFIX}/include


### PR DESCRIPTION
When I run `make -f scripts/packages.mk gtest`, it failed with error:
````
mv googletest-release-1.7.0 gtest
cd gtest; g++ -Iinclude -pthread -c src/gtest-all.cc -o gtest-all.o; cd ..
src/gtest-all.cc:42:10: fatal error: 'src/gtest.cc' file not found
#include "src/gtest.cc"
         ^~~~~~~~~~~~~~         
````

Reproduced on Mac OS and Ubuntu. It's also an issue for tvm cpp unittest build since it uses this script to install `gtest`. The fix is simple, just add the needed path.