### PR TITLE
Expose TemporaryDirectory as a feature

### DIFF
--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -1,0 +1,110 @@
+#include <dmlc/logging.h>
+
+/* platform specific headers */
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#include <Shlwapi.h>
+#pragma comment(lib, "Shlwapi.lib")
+#else
+#include <unistd.h>
+#endif
+
+namespace dmlc {
+
+class TemporaryDirectory {
+ public:
+  TemporaryDirectory(bool verbose = false)
+    : verbose_(verbose) {
+#if _WIN32
+    /* locate the root directory of temporary area */
+    char tmproot[MAX_PATH] = {0};
+    const DWORD dw_retval = GetTempPathA(MAX_PATH, tmproot);
+    if (dw_retval > MAX_PATH || dw_retval == 0) {
+      LOG(FATAL) << "TemporaryDirectory(): "
+                 << "Could not create temporary directory";
+    }
+    /* generate a unique 8-letter alphanumeric string */
+    const std::string letters = "abcdefghijklmnopqrstuvwxyz0123456789_";
+    std::string uniqstr(8, '\0');
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dis(0, letters.length() - 1);
+    std::generate(uniqstr.begin(), uniqstr.end(),
+      [&dis, &gen, &letters]() -> char {
+        return letters[dis(gen)];
+      });
+    /* combine paths to get the name of the temporary directory */
+    char tmpdir[MAX_PATH] = {0};
+    PathCombineA(tmpdir, tmproot, uniqstr.c_str());
+    if (!CreateDirectoryA(tmpdir, NULL)) {
+      LOG(FATAL) << "TemporaryDirectory(): "
+                 << "Could not create temporary directory";
+    }
+    path = std::string(tmpdir);
+#else
+    std::string tmproot; /* root directory of temporary area */
+    std::string dirtemplate; /* template for temporary directory name */
+    /* Get TMPDIR env variable or fall back to /tmp/ */
+    {
+      const char* tmpenv = getenv("TMPDIR");
+      if (tmpenv) {
+        tmproot = std::string(tmpenv);
+        // strip trailing forward slashes
+        while (tmproot.length() != 0 && tmproot[tmproot.length() - 1] == '/') {
+          tmproot.resize(tmproot.length() - 1);
+        }
+      } else {
+        tmproot = "/tmp";
+      }
+    }
+    dirtemplate = tmproot + "/tmpdir.XXXXXX";
+    std::vector<char> dirtemplate_buf(dirtemplate.begin(), dirtemplate.end());
+    dirtemplate_buf.push_back('\0');
+    char* tmpdir = mkdtemp(&dirtemplate_buf[0]);
+    if (!tmpdir) {
+      LOG(FATAL) << "TemporaryDirectory(): "
+                 << "Could not create temporary directory";
+    }
+    path = std::string(tmpdir);
+#endif
+    if (verbose_) {
+      LOG(INFO) << "Created temporary directory " << path;
+    }
+  }
+
+  ~TemporaryDirectory() {
+    for (const std::string& filename : file_list) {
+      if (std::remove(filename.c_str()) != 0) {
+        LOG(FATAL) << "Couldn't remove file " << filename;
+      }
+    }
+#if _WIN32
+    const bool rmdir_success = (RemoveDirectoryA(path.c_str()) != 0);
+#else
+    const bool rmdir_success = (rmdir(path.c_str()) == 0);
+#endif
+    if (rmdir_success) {
+      if (verbose_) {
+        LOG(INFO) << "Successfully deleted temporary directory " << path;
+      }
+    } else {
+      LOG(FATAL) << "~TemporaryDirectory(): "
+                 << "Could not remove temporary directory " << path;
+    }
+  }
+
+  std::string AddFile(const std::string& filename) {
+    const std::string file_path = this->path + "/" + filename;
+    file_list.push_back(file_path);
+    return file_path;
+  }
+
+  std::string path;
+
+ private:
+  std::vector<std::string> file_list;
+  bool verbose_;
+};
+
+}  // namespace dmlc

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -1,4 +1,15 @@
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file filesystem.h
+ * \brief Utilities to manipulate files
+ * \author Hyunsu Philip Cho
+ */
+#ifndef DMLC_FILESYSTEM_H_
+#define DMLC_FILESYSTEM_H_
+
 #include <dmlc/logging.h>
+#include <string>
+#include <vector>
 
 /* platform specific headers */
 #ifdef _WIN32
@@ -14,7 +25,7 @@ namespace dmlc {
 
 class TemporaryDirectory {
  public:
-  TemporaryDirectory(bool verbose = false)
+  explicit TemporaryDirectory(bool verbose = false)
     : verbose_(verbose) {
 #if _WIN32
     /* locate the root directory of temporary area */
@@ -108,3 +119,4 @@ class TemporaryDirectory {
 };
 
 }  // namespace dmlc
+#endif  // DMLC_FILESYSTEM_H_

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -129,13 +129,13 @@ class TemporaryDirectory {
     return file_path;
   }
 
-  /* \brief Path of the temporary directory */
+  /*! \brief Path of the temporary directory */
   std::string path;
 
  private:
-  /* \brief List of files being tracked  */
+  /*! \brief List of files being tracked  */
   std::vector<std::string> file_list_;
-  /* \brief Whether to emit extra messages */
+  /*! \brief Whether to emit extra messages */
   bool verbose_;
 };
 

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -23,6 +23,14 @@
 
 namespace dmlc {
 
+/*!
+ * \brief Manager class for temporary directories. Whenever a new object is
+ *        constructed, a temporary directory is created. The directory is
+ *        deleted when the object is deleted or goes out of scope.
+ *        NOTE. The class needs to keep track of all files inside the temporary
+ *        directory in order to delete the directory successfully in the end.
+ *        Thus, the user should call AddFile() method to add each file.
+ */
 class TemporaryDirectory {
  public:
   explicit TemporaryDirectory(bool verbose = false)

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -33,6 +33,10 @@ namespace dmlc {
  */
 class TemporaryDirectory {
  public:
+  /*!
+   * \brief Default constructor. Creates a new temporary directory
+   * \param verbose whether to emit extra messages
+   */
   explicit TemporaryDirectory(bool verbose = false)
     : verbose_(verbose) {
 #if _WIN32
@@ -93,7 +97,7 @@ class TemporaryDirectory {
   }
 
   ~TemporaryDirectory() {
-    for (const std::string& filename : file_list) {
+    for (const std::string& filename : file_list_) {
       if (std::remove(filename.c_str()) != 0) {
         LOG(FATAL) << "Couldn't remove file " << filename;
       }
@@ -113,16 +117,25 @@ class TemporaryDirectory {
     }
   }
 
+  /*!
+   * \brief Add a file under the temporary directory, to be tracked. When the
+   *        directory gets deleted, the file will get deleted also.
+   * \param filename name of the file
+   * \return full path of the file
+   */
   std::string AddFile(const std::string& filename) {
     const std::string file_path = this->path + "/" + filename;
-    file_list.push_back(file_path);
+    file_list_.push_back(file_path);
     return file_path;
   }
 
+  /* \brief Path of the temporary directory */
   std::string path;
 
  private:
-  std::vector<std::string> file_list;
+  /* \brief List of files being tracked  */
+  std::vector<std::string> file_list_;
+  /* \brief Whether to emit extra messages */
   bool verbose_;
 };
 

--- a/test/unittest/unittest_inputsplit.cc
+++ b/test/unittest/unittest_inputsplit.cc
@@ -1,4 +1,5 @@
 #include <dmlc/data.h>
+#include <dmlc/filesystem.h>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -8,16 +9,6 @@
 #include <future>
 #include <cstdlib>
 #include <gtest/gtest.h>
-
-/* platform specific headers */
-#ifdef _WIN32
-#define NOMINMAX
-#include <windows.h>
-#include <Shlwapi.h>
-#pragma comment(lib, "Shlwapi.lib")
-#else
-#include <unistd.h>
-#endif
 
 static inline void CountDimensions(dmlc::Parser<uint32_t>* parser,
                                    size_t* out_num_row, size_t* out_num_col) {
@@ -35,100 +26,11 @@ static inline void CountDimensions(dmlc::Parser<uint32_t>* parser,
   *out_num_col = num_col;
 }
 
-class TemporaryDirectory {
- public:
-  TemporaryDirectory() {
-#if _WIN32
-    /* locate the root directory of temporary area */
-    char tmproot[MAX_PATH] = {0};
-    const DWORD dw_retval = GetTempPathA(MAX_PATH, tmproot);
-    if (dw_retval > MAX_PATH || dw_retval == 0) {
-      LOG(FATAL) << "TemporaryDirectory(): "
-                 << "Could not create temporary directory";
-    }
-    /* generate a unique 8-letter alphanumeric string */
-    const std::string letters = "abcdefghijklmnopqrstuvwxyz0123456789_";
-    std::string uniqstr(8, '\0');
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<int> dis(0, letters.length() - 1);
-    std::generate(uniqstr.begin(), uniqstr.end(),
-      [&dis, &gen, &letters]() -> char {
-        return letters[dis(gen)];
-      });
-    /* combine paths to get the name of the temporary directory */
-    char tmpdir[MAX_PATH] = {0};
-    PathCombineA(tmpdir, tmproot, uniqstr.c_str());
-    if (!CreateDirectoryA(tmpdir, NULL)) {
-      LOG(FATAL) << "TemporaryDirectory(): "
-                 << "Could not create temporary directory";
-    }
-    path = std::string(tmpdir);
-#else
-    std::string tmproot; /* root directory of temporary area */
-    std::string dirtemplate; /* template for temporary directory name */
-    /* Get TMPDIR env variable or fall back to /tmp/ */
-    {
-      const char* tmpenv = getenv("TMPDIR");
-      if (tmpenv) {
-        tmproot = std::string(tmpenv);
-        // strip trailing forward slashes
-        while (tmproot.length() != 0 && tmproot[tmproot.length() - 1] == '/') {
-          tmproot.resize(tmproot.length() - 1);
-        }
-      } else {
-        tmproot = "/tmp";
-      }
-    }
-    dirtemplate = tmproot + "/tmpdir.XXXXXX";
-    std::vector<char> dirtemplate_buf(dirtemplate.begin(), dirtemplate.end());
-    dirtemplate_buf.push_back('\0');
-    char* tmpdir = mkdtemp(&dirtemplate_buf[0]);
-    if (!tmpdir) {
-      LOG(FATAL) << "TemporaryDirectory(): "
-                 << "Could not create temporary directory";
-    }
-    path = std::string(tmpdir);
-#endif
-    LOG(INFO) << "Created temporary directory " << path;
-  }
-
-  ~TemporaryDirectory() {
-    for (const std::string& filename : file_list) {
-      if (std::remove(filename.c_str()) != 0) {
-        LOG(FATAL) << "Couldn't remove file " << filename;
-      }
-    }
-#if _WIN32
-    const bool rmdir_success = (RemoveDirectoryA(path.c_str()) != 0);
-#else
-    const bool rmdir_success = (rmdir(path.c_str()) == 0);
-#endif
-    if (rmdir_success) {
-      LOG(INFO) << "Successfully deleted temporary directory " << path;
-    } else {
-      LOG(FATAL) << "~TemporaryDirectory(): "
-                 << "Could not remove temporary directory " << path;
-    }
-  }
-
-  std::string AddFile(const std::string& filename) {
-    const std::string file_path = this->path + "/" + filename;
-    file_list.push_back(file_path);
-    return file_path;
-  }
-
-  std::string path;
-
- private:
-  std::vector<std::string> file_list;
-};
-
 TEST(InputSplit, test_split_csv_noeol) {
   size_t num_row, num_col;
   {
     /* Create a test case for partitioned csv with NOEOL */
-    TemporaryDirectory tempdir;
+    dmlc::TemporaryDirectory tempdir;
     {
       const std::string filename = tempdir.AddFile("train_0.csv");
       std::ofstream of(filename.c_str(), std::ios::binary);
@@ -159,7 +61,7 @@ TEST(InputSplit, test_split_csv_noeol) {
 TEST(InputSplit, test_split_libsvm_noeol) {
   {
     /* Create a test case for partitioned libsvm with NOEOL */
-    TemporaryDirectory tempdir;
+    dmlc::TemporaryDirectory tempdir;
     const char* line
       = "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
         "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1";
@@ -192,7 +94,7 @@ TEST(InputSplit, test_split_libsvm) {
   size_t num_row, num_col;
   {
     /* Create a test case for partitioned libsvm */
-    TemporaryDirectory tempdir;
+    dmlc::TemporaryDirectory tempdir;
     const int nfile = 5;
     for (int file_id = 0; file_id < nfile; ++file_id) {
       const std::string filename
@@ -216,7 +118,7 @@ TEST(InputSplit, test_split_libsvm) {
 TEST(InputSplit, test_split_libsvm_distributed) {
   {
     /* Create a test case for partitioned libsvm */
-    TemporaryDirectory tempdir;
+    dmlc::TemporaryDirectory tempdir;
     const char* line
       = "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
         "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1\n";


### PR DESCRIPTION
InputSplit unit tests implemented a class `TemporaryDirectory` to create temporary directories. This pull request moves it to header `dmlc/filesystem.h` so that other projects can use it.