### PR TITLE
Consolidate fopen64 warning

### DIFF
--- a/cmake/build_config.h.in
+++ b/cmake/build_config.h.in
@@ -4,7 +4,7 @@
 #cmakedefine FOPEN_64_PRESENT
 
 #if !defined(FOPEN_64_PRESENT) && DMLC_USE_FOPEN64
-  #warning "Redefining fopen64 with std::fopen"
+  #define DMLC_EMIT_FOPEN64_REDEFINE_WARNING
   #define fopen64 std::fopen
 #endif
 

--- a/include/dmlc/build_config.h
+++ b/include/dmlc/build_config.h
@@ -10,7 +10,7 @@
 #if DMLC_USE_FOPEN64 && \
   (!defined(__GNUC__) || (defined __ANDROID__) || (defined __FreeBSD__) \
   || (defined __APPLE__) || ((defined __MINGW32__) && !(defined __MINGW64__)))
-  #warning "Redefining fopen64 with std::fopen"
+  #define DMLC_EMIT_FOPEN64_REDEFINE_WARNING
   #define fopen64 std::fopen
 #endif
 

--- a/src/build_config.cc
+++ b/src/build_config.cc
@@ -1,0 +1,12 @@
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file build_config.cc
+ * \brief Companion source for build_config.h
+ * \author Hyunsu Philip Cho
+ */
+
+#include <dmlc/base.h>
+
+#ifdef DMLC_EMIT_FOPEN64_REDEFINE_WARNING
+  #warning "Redefining fopen64 with std::fopen"
+#endif  // DMLC_EMIT_FOPEN64_REDEFINE_WARNING


### PR DESCRIPTION
#432 introduced ability to redefine `fopen64` with `std::fopen` on some targets, where `fopen64` is not available. It generated a warning `Redefining fopen64 with std::fopen` each time a source file included `dmlc/base.h`, unnecessarily slowing down compilation. This pull request consolidates the warning to a single source file to reduce clutter.