### PR TITLE
Include librt in CMakeLists.txt to access clock_gettime()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,13 @@ if(WIN32 AND (NOT MSVC))  # On Windows, link Shlwapi.lib for non-MSVC compilers
   list(APPEND dmlccore_LINKER_LIBS Shlwapi)
 endif()
 
+# Check location of clock_gettime; if it's in librt, link it
+include(CheckLibraryExists)
+CHECK_LIBRARY_EXISTS(rt clock_gettime "time.h" HAVE_CLOCK_GETTIME_IN_LIBRT)
+if(HAVE_CLOCK_GETTIME_IN_LIBRT)
+  list(APPEND dmlccore_LINKER_LIBS rt)
+endif()
+
 # Older stdc++ enable c++11 items
 add_definitions(-D__USE_XOPEN2K8)
 


### PR DESCRIPTION
On some systems, you have to explicitly specify -lrt in order to access
clock_gettime(); otherwise you get error
```
ld: CMakeFiles/dmlc_unit_tests.dir/unittest_lockfree.cc.o: undefined reference to symbol 'clock_gettime@@GLIBC_2.2.5'
ld: note: 'clock_gettime@@GLIBC_2.2.5' is defined in DSO /lib64/librt.so.1 so try adding it to the linker command line
```

Makefile already specifies -lrt; let's do the same for CMakeLists.txt.