### PR TITLE
Redesign dmlc::TemporaryDirectory to allow recursive deletion

### DIFF
--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -32,7 +32,8 @@ namespace dmlc {
  * \brief Manager class for temporary directories. Whenever a new
  *        TemporaryDirectory object is constructed, a temporary directory is
  *        created. The directory is deleted when the object is deleted or goes
- *        out of scope.
+ *        out of scope. Note: no symbolic links are allowed inside the
+ *        temporary directory.
  *
  * Usage example:
  * \code
@@ -53,8 +54,8 @@ namespace dmlc {
 class TemporaryDirectory {
  public:
   /*!
-   * \brief Default constructor. Creates a new temporary directory with a unique
-   *        name.
+   * \brief Default constructor.
+   *        Creates a new temporary directory with a unique name.
    * \param verbose whether to emit extra messages
    */
   explicit TemporaryDirectory(bool verbose = false)

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -33,6 +33,22 @@ namespace dmlc {
  *        TemporaryDirectory object is constructed, a temporary directory is
  *        created. The directory is deleted when the object is deleted or goes
  *        out of scope.
+ *
+ * Usage example:
+ * \code
+ *
+ *   void foo() {
+ *     dmlc::TemporaryDirectory tempdir;
+ *     // Create a file my_file.txt inside the temporary directory
+ *     std::ofstream of(tempdir.path + "/my_file.txt");
+ *     // ... write to my_file.txt ...
+ *
+ *     // ... use my_file.txt
+ *
+ *     // When tempdir goes out of scope, the temporary directory is deleted
+ *   }
+ *
+ * \endcode
  */
 class TemporaryDirectory {
  public:

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -29,17 +29,16 @@
 namespace dmlc {
 
 /*!
- * \brief Manager class for temporary directories. Whenever a new object is
- *        constructed, a temporary directory is created. The directory is
- *        deleted when the object is deleted or goes out of scope.
- *        NOTE. The class needs to keep track of all files inside the temporary
- *        directory in order to delete the directory successfully in the end.
- *        Thus, the user should call AddFile() method to add each file.
+ * \brief Manager class for temporary directories. Whenever a new
+ *        TemporaryDirectory object is constructed, a temporary directory is
+ *        created. The directory is deleted when the object is deleted or goes
+ *        out of scope.
  */
 class TemporaryDirectory {
  public:
   /*!
-   * \brief Default constructor. Creates a new temporary directory
+   * \brief Default constructor. Creates a new temporary directory with a unique
+   *        name.
    * \param verbose whether to emit extra messages
    */
   explicit TemporaryDirectory(bool verbose = false)
@@ -101,16 +100,22 @@ class TemporaryDirectory {
     }
   }
 
+  /*! \brief Destructor. Will perform recursive deletion via RecursiveDelete() */
   ~TemporaryDirectory() {
     RecursiveDelete(path);
   }
 
+  /*! \brief Full path of the temporary directory */
   std::string path;
 
  private:
   /*! \brief Whether to emit extra messages */
   bool verbose_;
 
+  /*!
+   * \brief Determine whether a given path is a symbolic link
+   * \param path String representation of path
+   */
   inline bool IsSymlink(const std::string& path) {
 #ifdef _WIN32
     DWORD attr = GetFileAttributesA(path.c_str());
@@ -125,6 +130,10 @@ class TemporaryDirectory {
 #endif  // _WIN32
   }
 
+  /*!
+   * \brief Delete a directory recursively, along with sub-directories and files.
+   * \param path String representation of path. It must refer to a directory.
+   */
   inline void RecursiveDelete(const std::string& path) {
     io::URI uri(path.c_str());
     io::FileSystem* fs = io::FileSystem::GetInstance(uri);

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -8,6 +8,7 @@
 #define DMLC_FILESYSTEM_H_
 
 #include <dmlc/logging.h>
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <random>

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 #include <random>
-#include <memory>
 
 /* platform specific headers */
 #ifdef _WIN32
@@ -128,7 +127,7 @@ class TemporaryDirectory {
 
   inline void RecursiveDelete(const std::string& path) {
     io::URI uri(path.c_str());
-    std::unique_ptr<io::FileSystem> fs(io::FileSystem::GetInstance(uri));
+    io::FileSystem* fs = io::FileSystem::GetInstance(uri);
     std::vector<io::FileInfo> file_list;
     fs->ListDirectory(uri, &file_list);
     for (io::FileInfo info : file_list) {

--- a/test/unittest/unittest_inputsplit.cc
+++ b/test/unittest/unittest_inputsplit.cc
@@ -32,18 +32,15 @@ TEST(InputSplit, test_split_csv_noeol) {
     /* Create a test case for partitioned csv with NOEOL */
     dmlc::TemporaryDirectory tempdir;
     {
-      const std::string filename = tempdir.AddFile("train_0.csv");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/train_0.csv", std::ios::binary);
       of << "0,1,1,1";  // NOEOL (no '\n' at end of file)
     }
     {
-      const std::string filename = tempdir.AddFile("train_1.csv");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/train_1.csv", std::ios::binary);
       of << "0,1,1,2\n";
     }
     {
-      const std::string filename = tempdir.AddFile("train_2.csv");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/train_2.csv", std::ios::binary);
       of << "0,1,1,2\n";
     }
     /* Load the test case with InputSplit and obtain matrix dimensions */
@@ -66,13 +63,11 @@ TEST(InputSplit, test_split_libsvm_noeol) {
       = "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
         "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1";
     {
-      const std::string filename = tempdir.AddFile("train_0.libsvm");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/train_0.libsvm", std::ios::binary);
       of << line << "\n";
     }
     {
-      const std::string filename = tempdir.AddFile("train_1.libsvm");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/train_1.libsvm", std::ios::binary);
       of << line;  // NOEOL (no '\n' at end of file)
     }
     std::unique_ptr<dmlc::Parser<uint32_t> > parser(
@@ -91,9 +86,8 @@ TEST(InputSplit, test_split_libsvm) {
     dmlc::TemporaryDirectory tempdir;
     const int nfile = 5;
     for (int file_id = 0; file_id < nfile; ++file_id) {
-      const std::string filename
-        = tempdir.AddFile(std::string("test_") + std::to_string(file_id) + ".libsvm");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/test_" + std::to_string(file_id) + ".libsvm",
+                       std::ios::binary);
       of << "1 3:1 10:1 11:1 21:1 30:1 34:1 36:1 40:1 41:1 53:1 58:1 65:1 69:1 "
          << "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1\n";
     }
@@ -118,9 +112,8 @@ TEST(InputSplit, test_split_libsvm_distributed) {
         "77:1 86:1 88:1 92:1 95:1 102:1 105:1 117:1 124:1\n";
     const int nfile = 5;
     for (int file_id = 0; file_id < nfile; ++file_id) {
-      const std::string filename
-        = tempdir.AddFile(std::string("test_") + std::to_string(file_id) + ".libsvm");
-      std::ofstream of(filename.c_str(), std::ios::binary);
+      std::ofstream of(tempdir.path + "/test_" + std::to_string(file_id) + ".libsvm",
+                       std::ios::binary);
       const int nrepeat = (file_id == 0 ? 6 : 1);
       for (int i = 0; i < nrepeat; ++i) {
         of << line;

--- a/test/unittest/unittest_tempdir.cc
+++ b/test/unittest/unittest_tempdir.cc
@@ -33,9 +33,9 @@ TEST(TemporaryDirectory, test_basic) {
     for (int i = 0; i < num_file; ++i) {
       std::ifstream fin(tempdir.path + "/" + std::to_string(i) + ".txt");
       std::string s;
-      ASSERT_TRUE(std::getline(fin, s));
+      ASSERT_TRUE(static_cast<bool>(std::getline(fin, s)));
       ASSERT_EQ(s, std::string("0,1,1," + std::to_string(i + 1)));
-      ASSERT_FALSE(std::getline(fin, s));
+      ASSERT_FALSE(static_cast<bool>(std::getline(fin, s)));
     }
   }
   // Test the directory is indeed deleted.

--- a/test/unittest/unittest_tempdir.cc
+++ b/test/unittest/unittest_tempdir.cc
@@ -1,0 +1,77 @@
+#include <dmlc/filesystem.h>
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+#include <queue>
+#include <utility>
+
+#ifdef _WIN32
+#include <direct.h>
+#else  // _WIN32
+#include <sys/stat.h>
+#endif  // _WIN32
+
+static inline void MakeDirectory(const std::string& path) {
+#ifdef _WIN32
+  CHECK_EQ(_mkdir(path.c_str()), 0) << "Failed to make directory " << path;
+#else  // _WIN32
+  CHECK_EQ(mkdir(path.c_str(), 0777), 0) << "Failed to make directory " << path;
+#endif  // _WIN32
+}
+
+TEST(TemporaryDirectory, test_basic) {
+  std::string tempdir_path;
+  {
+    dmlc::TemporaryDirectory tempdir;
+    tempdir_path = tempdir.path;
+    const int num_file = 5;
+    for (int i = 0; i < num_file; ++i) {
+      std::ofstream fout(tempdir.path + "/" + std::to_string(i) + ".txt");
+      fout << "0,1,1," << (i + 1) << "\n";
+    }
+    // Check if each file can be read back
+    for (int i = 0; i < num_file; ++i) {
+      std::ifstream fin(tempdir.path + "/" + std::to_string(i) + ".txt");
+      std::string s;
+      ASSERT_TRUE(std::getline(fin, s));
+      ASSERT_EQ(s, std::string("0,1,1," + std::to_string(i + 1)));
+      ASSERT_FALSE(std::getline(fin, s));
+    }
+  }
+  // Test the directory is indeed deleted.
+  const dmlc::io::URI uri(tempdir_path.c_str());
+  ASSERT_ANY_THROW(dmlc::io::FileSystem::GetInstance(uri)->GetPathInfo(uri));
+}
+
+TEST(TemporaryDirectory, test_recursive) {
+  std::string tempdir_path;
+  {
+    dmlc::TemporaryDirectory tempdir;
+    tempdir_path = tempdir.path;
+    const int recurse_depth = 5;
+
+    std::queue<std::pair<int, std::string>> Q;  // (depth, directory)
+    Q.emplace(0, tempdir.path);
+    while (!Q.empty()) {
+      auto e = Q.front(); Q.pop();
+      const int current_depth = e.first;
+      const std::string current_directory = e.second;
+      if (current_depth < recurse_depth) {
+        {
+          std::ofstream of(current_directory + "/foobar.txt");
+          of << "hello world\n";
+        }
+        MakeDirectory(current_directory + "/1");
+        MakeDirectory(current_directory + "/2");
+        Q.emplace(current_depth + 1, current_directory + "/1");
+        Q.emplace(current_depth + 1, current_directory + "/2");
+      } else {
+        std::ofstream of(current_directory + "/foobar.txt");
+        of << "hello world\n";
+      }
+    }
+  }
+  // Test the directory is indeed deleted.
+  const dmlc::io::URI uri(tempdir_path.c_str());
+  ASSERT_ANY_THROW(dmlc::io::FileSystem::GetInstance(uri)->GetPathInfo(uri));
+}


### PR DESCRIPTION
Use `dmlc::io::LocalFileSystem::ListDirectory()` to allow recursive deletion of temporary directories. Now users don't have to call `AddFile()`; it suffices to create files inside the directory.

Limitation: no symbolic links are allowed inside the temporary directory.