### PR TITLE
Fix broken Travis OSX CI

### DIFF
--- a/scripts/travis/travis_osx_install.sh
+++ b/scripts/travis/travis_osx_install.sh
@@ -9,7 +9,7 @@ fi
 # Update command line tool to avoid an error:
 # "_stdio.h: No such file or directory"
 softwareupdate --list
-softwareupdate --install "Command Line Tools (macOS High Sierra version 10.13) for Xcode-9.4"
+softwareupdate --install "Command Line Tools (macOS High Sierra version 10.13) for Xcode-10.1"
 
 brew install gcc@7 || brew link --overwrite gcc@7
 brew update


### PR DESCRIPTION
Remove the error `/usr/local/Cellar/gcc@7/7.3.0/lib/gcc/7/gcc/x86_64-apple-darwin17.7.0/7.3.0/include-fixed/stdio.h:78:10: fatal error: _stdio.h: No such file or directory`. Example: https://travis-ci.org/dmlc/dmlc-core/jobs/449672677