### PR TITLE
Handle 'f' suffix in float parsing

### DIFF
--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -199,6 +199,10 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
     // Return signed and scaled floating point result.
     value = frac ? (value / scale) : (value * scale);
   }
+  // Consume 'f' suffix, if any
+  if (*p == 'f' || *p == 'F') {
+    ++p;
+  }
 
   if (endptr) *endptr = (char*)p;  // NOLINT(*)
   return sign ? value : - value;

--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -190,8 +190,8 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
         if (endptr) *endptr = (char*)p;  // NOLINT(*)
         return std::numeric_limits<FloatType>::infinity();
       }
-      value = (frac ? kMaxSignificandForMaxExponent
-                    : kMaxSignificandForNegMaxExponent);
+      value = (frac ? kMaxSignificandForNegMaxExponent
+                    : kMaxSignificandForMaxExponent);
     }
     // Calculate scaling factor.
     while (expon >= 8U) { scale *= static_cast<FloatType>(1E8f);  expon -= 8U; }

--- a/test/unittest/unittest_param.cc
+++ b/test/unittest/unittest_param.cc
@@ -29,6 +29,10 @@ TEST(Parameter, parsing_float) {
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["float_param"] = "1e10";
   ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["float_param"] = "1.2f";
+  ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["float_param"] = "1.2e-2f";
+  ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["float_param"] = "3.4e+38";
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["float_param"] = "1.2e-38";
@@ -76,6 +80,10 @@ TEST(Parameter, parsing_float) {
   kwargs["double_param"] = "1e-10";
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["double_param"] = "1e10";
+  ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["double_param"] = "1.2f";
+  ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["double_param"] = "1.2e-2f";
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["double_param"] = "1e-100";
   ASSERT_NO_THROW(param.Init(kwargs));


### PR DESCRIPTION
There are existing programs that use `f` suffix in float parameter, e.g.
https://github.com/apache/incubator-mxnet/blob/c00697cc9e8fed457e4b644062e8c4fcce72f02c/cpp-package/include/mxnet-cpp/optimizer.hpp#L63-L64