### PR TITLE
Remove dead-lock from ApplicationMaster caused by nmClient

### DIFF
--- a/tracker/yarn/src/main/java/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
+++ b/tracker/yarn/src/main/java/org/apache/hadoop/yarn/dmlc/ApplicationMaster.java
@@ -279,7 +279,6 @@ public class ApplicationMaster {
             diagnostics = "Diagnostics." + ", num_tasks" + this.numTasks
                 + ", finished=" + this.finishedTasks.size() + ", failed="
                 + this.killedTasks.size() + "\n" + this.abortDiagnosis;
-            nmClient.stop();
             LOG.info(diagnostics);
         } catch (Exception e) {
             diagnostics = e.toString();


### PR DESCRIPTION
We were experiencing an issue where the Dmlc Yarn ApplicationMaster was hanging upon training launch failures. For our use-case, launch failures were typically triggered due to malformed 
 or nonexistent training/eval data paths. 

We dug a little deeper and found out that the ApplicationMaster was stuck in a deadlock. Here's a snippet from our jstack log: 

```
Found one Java-level deadlock:
=============================
"org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl #217":
  waiting to lock monitor 0x00007fedb1169d08 (object 0x00000000c7ca5850, a org.apache.hadoop.yarn.client.api.impl.NMClientImpl),
  which is held by "main"
"main":
  waiting to lock monitor 0x00007fedb1168188 (object 0x00000000c814e1b8, a org.apache.hadoop.yarn.client.api.impl.NMClientImpl$StartedContainer),
  which is held by "org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl #72"
"org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl #72":
  waiting to lock monitor 0x00007fedb1169d08 (object 0x00000000c7ca5850, a org.apache.hadoop.yarn.client.api.impl.NMClientImpl),
  which is held by "main"
```

The root cause is that upon some training failure event, the application master invokes `this.abortJob`, triggering `nmClient.stopContainerAsync` for all running containers. Since this is an Async call, ApplicationMaster then goes ahead and invokes `nmClient.stop()` at the end of the `run` method, which can cause a deadlock (We typically spawn 50 ~ 150 workers for large-scale training). 

**Fix**:
This `nmClient.stop()` is not necessary, since Yarn should handle the cleanup when the application exits. 

