### PR TITLE
Use 64-bit fstat in 32-bit Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
     - git submodule update --init --recursive
     # Set PATH
     - if /i "%target%" == "msys2" set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
-    - if /i "%target%" == "mingw32" set PATH=C:\MinGW\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    - if /i "%target%" == "mingw32" set PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if /i "%target%" == "mingw" set PATH=C:\MinGW-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if /i "%target%" == "cygwin" set PATH=C:\cygwin64\bin;C:\cygwin64\usr\bin;%PATH%
     # Install packages and show information

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 environment:
     matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          target: mingw32
+          generator: "MinGW Makefiles"
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           target: cygwin
           generator: "Unix Makefiles"
@@ -45,6 +48,7 @@ install:
     - git submodule update --init --recursive
     # Set PATH
     - if /i "%target%" == "msys2" set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%
+    - if /i "%target%" == "mingw32" set PATH=C:\MinGW\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if /i "%target%" == "mingw" set PATH=C:\MinGW-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if /i "%target%" == "cygwin" set PATH=C:\cygwin64\bin;C:\cygwin64\usr\bin;%PATH%
     # Install packages and show information
@@ -77,6 +81,12 @@ build_script:
         cmake .. -G"%generator%" -DGOOGLE_TEST=ON &&
         cmake --build . -- -j2
       )
+    - if /i "%target%" == "mingw32" (
+        mkdir build_mingw32 &&
+        cd build_mingw32 &&
+        cmake .. -G"%generator%" -DGOOGLE_TEST=ON &&
+        cmake --build . -- -j2
+      )
     - if /i "%target%" == "mingw" (
         mkdir build_mingw &&
         cd build_mingw &&
@@ -99,6 +109,9 @@ test_script:
       )
     - if /i "%target%" == "msys2" (
         .\build_msys2\test\unittest\dmlc_unit_tests.exe
+      )
+    - if /i "%target%" == "mingw32" (
+        .\build_mingw32\test\unittest\dmlc_unit_tests.exe
       )
     - if /i "%target%" == "mingw" (
         .\build_mingw\test\unittest\dmlc_unit_tests.exe

--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -11,9 +11,11 @@ extern "C" {
 #include <sys/types.h>
 #include <dirent.h>
 }
+#define stat_struct stat
 #else  // _WIN32
 #include <Windows.h>
 #define stat _stat64
+#define stat_struct __stat64
 #endif  // _WIN32
 
 #include "./local_filesys.h"
@@ -65,7 +67,7 @@ class FileStream : public SeekStream {
 };
 
 FileInfo LocalFileSystem::GetPathInfo(const URI &path) {
-  struct stat sb;
+  struct stat_struct sb;
   FileInfo ret;
   ret.path = path;
   if (stat(path.name.c_str(), &sb) == -1) {

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -16,8 +16,11 @@
 #include <algorithm>
 
 #ifdef _WIN32
+#define stat_struct __stat64
 #define fstat _fstat64
 #define fileno _fileno
+#else  // _WIN32
+#define stat_struct stat
 #endif  // _WIN32
 
 namespace dmlc {
@@ -56,7 +59,7 @@ class SingleFileSplit : public InputSplit {
     buffer_size_ = std::max(chunk_size, buffer_size_);
   }
   virtual size_t GetTotalSize(void) {
-    struct stat buf;
+    struct stat_struct buf;
     fstat(fileno(fp_), &buf);
     return buf.st_size;
   }

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -15,6 +15,10 @@
 #include <string>
 #include <algorithm>
 
+#ifdef _WIN32
+#define fstat _fstat64
+#define fileno _fileno
+#endif  // _WIN32
 
 namespace dmlc {
 namespace io {


### PR DESCRIPTION
This is to fix compilation error in 32-bit MinGW: https://ci.appveyor.com/project/tqchen/xgboost/builds/20250666/job/fpnycgt0frv1u87x#L1583

It turns out that CRAN submission requires compatibility with 32-bit MinGW.