### PR TITLE
Suppress unreachable condition warning.

### DIFF
--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -178,8 +178,9 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
         errno = ERANGE;
         if (endptr) *endptr = (char*)p;  // NOLINT(*)
         return std::numeric_limits<FloatType>::infinity();
+      } else {
+        expon = kMaxExponent;
       }
-      expon = kMaxExponent;
     }
     // handle edge case where exponent is exactly kMaxExponent
     if (expon == kMaxExponent
@@ -189,9 +190,10 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
         errno = ERANGE;
         if (endptr) *endptr = (char*)p;  // NOLINT(*)
         return std::numeric_limits<FloatType>::infinity();
+      } else {
+        value = (frac ? kMaxSignificandForNegMaxExponent
+                 : kMaxSignificandForMaxExponent);
       }
-      value = (frac ? kMaxSignificandForNegMaxExponent
-                    : kMaxSignificandForMaxExponent);
     }
     // Calculate scaling factor.
     while (expon >= 8U) { scale *= static_cast<FloatType>(1E8f);  expon -= 8U; }


### PR DESCRIPTION
Running g++7 generates a large amount of unreachable code warnings.
@hcho3 