### PR TITLE
Do not throw for possible integer truncation

### DIFF
--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -90,10 +90,6 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
                "ParseFloat is defined only for 'float' and 'double' types");
   constexpr unsigned kMaxExponent
     = (std::is_same<FloatType, double>::value ? 308U : 38U);
-  constexpr uint64_t kMaxPreDecimalDigits
-    = (std::is_same<FloatType, double>::value ? 0x20000000000000ULL : 0x1000000ULL);
-    // Largest integer that IEEE 754 floating-point value is capable of
-    // representing exactly
   constexpr FloatType kMaxSignificandForMaxExponent
     = static_cast<FloatType>(std::is_same<FloatType, double>::value
                              ? 1.79769313486231570 : 3.402823466);
@@ -107,8 +103,6 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
 #else
   const unsigned kMaxExponent
     = (sizeof(FloatType) == sizeof(double) ? 308U : 38U);
-  const uint64_t kMaxPreDecimalDigits
-    = (sizeof(FloatType) == sizeof(double) ? 0x20000000000000ULL : 0x1000000ULL);
   const FloatType kMaxSignificandForMaxExponent
     = static_cast<FloatType>(sizeof(FloatType) == sizeof(double)
                              ? 1.79769313486231570 : 3.402823466);
@@ -134,8 +128,6 @@ inline FloatType ParseFloat(const char* nptr, char** endptr) {
   for (predec = 0; isdigit(*p); ++p) {
     predec = predec * 10ULL + static_cast<uint64_t>(*p - '0');
   }
-  CHECK_LE(predec, kMaxPreDecimalDigits)
-    << "Too many digits before the decimal point; use scientific notation instead";
   FloatType value = static_cast<FloatType>(predec);
 
   // Get digits after decimal point, if any.

--- a/test/unittest/unittest_param.cc
+++ b/test/unittest/unittest_param.cc
@@ -39,6 +39,10 @@ TEST(Parameter, parsing_float) {
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["float_param"] = "16777216.01";
   ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["float_param"] = "4.920005e9";
+  ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["float_param"] = "4920000500.0";
+  ASSERT_NO_THROW(param.Init(kwargs));
 
   // Range error should be caught
   kwargs["float_param"] = "1e-100";
@@ -49,12 +53,6 @@ TEST(Parameter, parsing_float) {
   ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
   kwargs["float_param"] = "1.1e-38";
   ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
-
-  // Too many digits before the decimal point should throw error
-  kwargs["float_param"] = "16777217.01";
-  ASSERT_THROW(param.Init(kwargs), dmlc::Error);
-  kwargs["float_param"] = "100000000.01";
-  ASSERT_THROW(param.Init(kwargs), dmlc::Error);
 
   // Invalid inputs should be detected
   kwargs["float_param"] = "foobar";
@@ -99,6 +97,10 @@ TEST(Parameter, parsing_float) {
   ASSERT_NO_THROW(param.Init(kwargs));
   kwargs["double_param"] = "9007199254740992.01";
   ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["double_param"] = "4.920005e9";
+  ASSERT_NO_THROW(param.Init(kwargs));
+  kwargs["double_param"] = "4920000500.0";
+  ASSERT_NO_THROW(param.Init(kwargs));
 
   // Range error should be caught
   kwargs["double_param"] = "1e-500";
@@ -109,12 +111,6 @@ TEST(Parameter, parsing_float) {
   ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
   kwargs["double_param"] = "2.2e-308";
   ASSERT_THROW(param.Init(kwargs), dmlc::ParamError);
-
-  // Too many digits before the decimal point should throw error
-  kwargs["double_param"] = "9007199254740993.01";
-  ASSERT_THROW(param.Init(kwargs), dmlc::Error);
-  kwargs["double_param"] = "10000000000000000.01";
-  ASSERT_THROW(param.Init(kwargs), dmlc::Error);
 
   // Invalid inputs should be detected
   kwargs["double_param"] = "foobar";


### PR DESCRIPTION
See dmlc/xgboost#3906. Current implementation throws whenever the pre-decimal digits exceed 16777216. This was to prevent possible truncation of integers. However, this behavior is far too
aggressive, since a value 4920000500 is just 4.920005e9, which is perfectly fine for float.

Fix: Eliminate the pre-decimal check.