### PR TITLE
Better detection logic for backtrace(3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,18 @@ include(CheckIncludeFile)
 include(CheckIncludeFileCXX)
 check_symbol_exists(fopen64 stdio.h DMLC_FOPEN_64_PRESENT)
 check_include_file_cxx(cxxabi.h DMLC_CXXABI_H_PRESENT)
-check_include_file(execinfo.h DMLC_EXECINFO_H_PRESENT)
-
 check_symbol_exists(nanosleep time.h DMLC_NANOSLEEP_PRESENT)
+
+# Check existence of backtrace(3)
+find_package(Backtrace)
+if(Backtrace_FOUND)
+  set(DMLC_EXECINFO_H_PRESENT 1)
+  set(DMLC_EXECINFO_H ${Backtrace_HEADER})
+  include_directories(${Backtrace_INCLUDE_DIRS})
+  list(APPEND dmlccore_LINKER_LIBS ${Backtrace_LIBRARIES})
+else()
+  set(DMLC_EXECINFO_H_PRESENT 0)
+endif()
 
 # Check endianness
 include(TestBigEndian)

--- a/cmake/build_config.h.in
+++ b/cmake/build_config.h.in
@@ -14,6 +14,7 @@
 #if (defined DMLC_CXXABI_H_PRESENT) && (defined DMLC_EXECINFO_H_PRESENT)
   #define DMLC_LOG_STACK_TRACE 1
   #define DMLC_LOG_STACK_TRACE_SIZE 10
+  #cmakedefine DMLC_EXECINFO_H <${DMLC_EXECINFO_H}>
 #endif
 
 #cmakedefine DMLC_NANOSLEEP_PRESENT

--- a/include/dmlc/build_config.h
+++ b/include/dmlc/build_config.h
@@ -24,6 +24,7 @@
      && !defined(__CYGWIN__)
   #define DMLC_LOG_STACK_TRACE 1
   #define DMLC_LOG_STACK_TRACE_SIZE 10
+  #define DMLC_EXECINFO_H <execinfo.h>
 #endif
 
 /* default logic for detecting existence of nanosleep() */

--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -17,10 +17,7 @@
 
 #if DMLC_LOG_STACK_TRACE
 #include <cxxabi.h>
-#endif
-
-#if DMLC_LOG_STACK_TRACE
-#include <execinfo.h>
+#include DMLC_EXECINFO_H
 #endif
 
 namespace dmlc {


### PR DESCRIPTION
Checking the existence of `<execinfo.h>` is not sufficient, since the backtrace(3) library can be still missing. This is the case for systems using GCC+MUSL combination. See discussion at https://github.com/dmlc/xgboost/issues/3649#issuecomment-441196233.

Fix. Use CMake's FindBacktrace package instead.