### PR TITLE
Add unsafe_get to dmlc::any

### DIFF
--- a/include/dmlc/json.h
+++ b/include/dmlc/json.h
@@ -557,7 +557,7 @@ class AnyJSONManager {
 
   template<typename T>
   inline static void WriteAny(JSONWriter *writer, const any &data) {
-    writer->Write(dmlc::get<T>(data));
+    writer->Write(dmlc::unsafe_get<T>(data));
   }
   template<typename T>
   inline static void ReadAny(JSONReader *reader, any* data) {


### PR DESCRIPTION
In newer versions of GCC/Clang, typeid() comparison is based on the memory addresses of structures characterizing the types, these structures are unfortunately linked separately into each boundary, thus causing this problem when using `dmlc::any` across the boundary (same for `std::any` and `boost::any`).

The "unsafe" versions of `get` is required when where we know what type is stored in the any and can't use `typeid()` comparison, e.g., when our types may travel across different shared libraries. This fix introduces string-based comparison as some compilers do.

[1] https://svn.boost.org/trac10/ticket/754
[2] https://stackoverflow.com/questions/922442/unique-class-type-id-that-is-safe-and-holds-across-library-boundaries/34785867
