### PR TITLE
Fix typo in json.h

### DIFF
--- a/include/dmlc/json.h
+++ b/include/dmlc/json.h
@@ -88,7 +88,7 @@ class JSONReader {
    *  // value can be any type that is json serializable.
    *  std::string value;
    *  reader->BeginArray();
-   *  while (reader->NextObjectArrayItem(&value)) {
+   *  while (reader->NextArrayItem(&value)) {
    *    // do somthing to value
    *  }
    * \endcode


### PR DESCRIPTION
The code example in a comment refers to a non-existent function `NextObjectArrayItem()`.