### PR TITLE
Avoid double-free in LogCheckError

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -68,8 +68,14 @@ class LogCheckError {
  public:
   LogCheckError() : str(nullptr) {}
   explicit LogCheckError(const std::string& str_) : str(new std::string(str_)) {}
+  LogCheckError(const LogCheckError& other) = delete;
+  LogCheckError(LogCheckError&& other) : str(other.str) {
+    other.str = nullptr;
+  }
   ~LogCheckError() { if (str != nullptr) delete str; }
-  operator bool() {return str != nullptr; }
+  operator bool() const { return str != nullptr; }
+  LogCheckError& operator=(const LogCheckError& other) = delete;
+  LogCheckError& operator=(LogCheckError&& other) = delete;
   std::string* str;
 };
 

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -310,7 +310,7 @@ namespace parameter {
 class FieldAccessEntry {
  public:
   FieldAccessEntry()
-      : has_default_(false) {}
+      : has_default_(false), index_(0) {}
   /*! \brief destructor */
   virtual ~FieldAccessEntry() {}
   /*!


### PR DESCRIPTION
The default copy constructor of `LogCheckError` could lead to double-free errors. An alternative to this fix would be to define the constructor and assigment operator (and move constructor?).