### PR TITLE
Add endian detection logic for Solaris

### DIFF
--- a/include/dmlc/endian.h
+++ b/include/dmlc/endian.h
@@ -22,6 +22,13 @@
     #define DMLC_LITTLE_ENDIAN (_BYTE_ORDER == _LITTLE_ENDIAN)
   #elif defined(__EMSCRIPTEN__)
     #define DMLC_LITTLE_ENDIAN 1
+  #elif defined(__sun) && defined(__SVR4)
+    // Solaris supports x86 (little endian) and SPARC (big endian)
+    #if defined(__x86_64) || defined(__i386__)
+      #define DMLC_LITTLE_ENDIAN 1
+    #else
+      #define DMLC_LITTLE_ENDIAN 0
+    #endif
   #else
     #error "Unable to determine endianness of your machine; use CMake to compile"
   #endif


### PR DESCRIPTION
CRAN uses Makefile to compile XGBoost-R, and we cannot rely on CMake to detect endian. CRAN requires that R packages support Solaris.

@hetong007 