### PR TITLE
Update warning message for missing S3 Region

### DIFF
--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1182,10 +1182,12 @@ S3FileSystem::S3FileSystem() {
     s3_is_aws_ = false;
   }
   if (region == NULL) {
-    LOG(WARNING) << "No AWS Region set, using default region us-east-1";
+    LOG(WARNING) << "No AWS Region set, using default region us-east-1.";
+    LOG(WARNING) << "Need to set enviroment variable S3_REGION to set region.";
     s3_region_ = "us-east-1";
   } else if (strcmp(region, "") == 0) {
-    LOG(WARNING) << "AWS Region was set to empty string, using default region us-east-1";
+    LOG(WARNING) << "AWS Region was set to empty string, using default region us-east-1.";
+    LOG(WARNING) << "Need to set enviroment variable S3_REGION to set region.";
     s3_region_ = "us-east-1";
   } else {
     s3_region_ = region;


### PR DESCRIPTION
The current warning message that is shown when the AWS Region for S3 is not set is little cryptic. It took me some time to figure out how to exactly set the AWS Region via Env Variables (It involved going through source etc.). 

I have updated the message to also include the Env Variable that should be set. This would help users in the future.

It is similar to existing messages for other Env Variables.

```python
 if (keyid == NULL) {
    LOG(FATAL) << "Need to set enviroment variable S3_ACCESS_KEY_ID to use S3";
  }
  if (seckey == NULL) {
    LOG(FATAL) << "Need to set enviroment variable S3_SECRET_ACCESS_KEY to use S3";
  }
```

The current stack trace looks like:
> [18:17:23] src/io/s3_filesys.cc:1185: No AWS Region set, using default region us-east-1
Traceback (most recent call last):
  File "train_args.py", line 347, in <module>
    main()
  File "train_args.py", line 310, in main
    custom_header=True) for phase in model_phases}
  File "train_args.py", line 310, in <dictcomp>
    custom_header=True) for phase in model_phases}
  File "<>.py", line 18, in __init__
    super(<>, self).__init__(filename)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/gluon/data/dataset.py", line 183, in __init__
    self._fork()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/gluon/data/dataset.py", line 186, in _fork
    self._record = recordio.MXIndexedRecordIO(self.idx_file, self.filename, 'r')
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/recordio.py", line 199, in __init__
    super(MXIndexedRecordIO, self).__init__(uri, flag)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/recordio.py", line 69, in __init__
    self.open()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/recordio.py", line 202, in open
    super(MXIndexedRecordIO, self).open()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/recordio.py", line 77, in open
    check_call(_LIB.MXRecordIOReaderCreate(self.uri, ctypes.byref(self.handle)))
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/base.py", line 252, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [18:17:23] src/io/s3_filesys.cc:1096: <?xml version="1.0" encoding="UTF-8"?
<Error><Code>AuthorizationHeaderMalformed</Code><Message>The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-west-2'</Message><Region>us-west-2</Region><RequestId></RequestId><HostId></HostId></Error>
Stack trace returned 10 entries:
[bt] (0) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x36161a) [0x7f19a457161a]
[bt] (1) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x361c31) [0x7f19a4571c31]
[bt] (2) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x316cf35) [0x7f19a737cf35]
[bt] (3) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x316f103) [0x7f19a737f103]
[bt] (4) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x316f895) [0x7f19a737f895]
[bt] (5) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x31726d8) [0x7f19a73826d8]
[bt] (6) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(+0x313ce7a) [0x7f19a734ce7a]
[bt] (7) /home/ubuntu/anaconda3/lib/python3.6/site-packages/mxnet/libmxnet.so(MXRecordIOReaderCreate+0x2d) [0x7f19a6be9cdd]
[bt] (8) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/../../libffi.so.6(ffi_call_unix64+0x4c) [0x7f19e025aec0]
[bt] (9) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/../../libffi.so.6(ffi_call+0x22d) [0x7f19e025a87d]
