### PR TITLE
[Bugfix] Missing #include <sstream>

### DIFF
--- a/include/dmlc/json.h
+++ b/include/dmlc/json.h
@@ -11,6 +11,7 @@
 #include <vector>
 #ifndef _LIBCPP_SGX_NO_IOSTREAMS
 #include <iostream>
+#include <sstream>
 #endif
 #include <cctype>
 #include <string>


### PR DESCRIPTION
`std::ostringstream` is only defined in `<sstream>` on some platforms