### PR TITLE
Add noexcept in DataIter, InputSplit

### DIFF
--- a/include/dmlc/common.h
+++ b/include/dmlc/common.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <sstream>
 #include <mutex>
+#include <utility>
 #include "./logging.h"
 
 namespace dmlc {

--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -14,6 +14,7 @@
 #include <mutex>
 #include <vector>
 #include <condition_variable>
+#include <utility>
 #include "dmlc/base.h"
 
 namespace dmlc {

--- a/include/dmlc/data.h
+++ b/include/dmlc/data.h
@@ -56,7 +56,7 @@ template<typename DType>
 class DataIter {
  public:
   /*! \brief destructor */
-  virtual ~DataIter(void) {}
+  virtual ~DataIter(void) DMLC_THROW_EXCEPTION {}
   /*! \brief set before first of the item */
   virtual void BeforeFirst(void) = 0;
   /*! \brief move to next item */

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -230,7 +230,7 @@ class InputSplit {
     return NextChunk(out_chunk);
   }
   /*! \brief destructor*/
-  virtual ~InputSplit(void) {}
+  virtual ~InputSplit(void) DMLC_THROW_EXCEPTION {}
   /*!
    * \brief reset the Input split to a certain part id,
    *  The InputSplit will be pointed to the head of the new specified segment.

--- a/include/dmlc/memory.h
+++ b/include/dmlc/memory.h
@@ -7,6 +7,8 @@
 #define DMLC_MEMORY_H_
 
 #include <vector>
+#include <memory>
+#include <utility>
 #include "./base.h"
 #include "./logging.h"
 #include "./thread_local.h"

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -25,7 +25,7 @@ struct nullopt_t {
   explicit nullopt_t(int a) {}
 #else
   /*! \brief dummy constructor */
-  constexpr nullopt_t(int a) {}
+  explicit constexpr nullopt_t(int a) {}
 #endif
 };
 

--- a/include/dmlc/thread_group.h
+++ b/include/dmlc/thread_group.h
@@ -13,6 +13,8 @@
 #include <mutex>
 #include <set>
 #include <thread>
+#include <memory>
+#include <utility>
 #include <unordered_set>
 #include <unordered_map>
 #if defined(DMLC_USE_CXX14) || __cplusplus > 201103L  /* C++14 */


### PR DESCRIPTION
This PR is created in addition to [https://github.com/apache/incubator-mxnet/pull/14223](https://github.com/apache/incubator-mxnet/pull/14223) and [https://github.com/dmlc/mshadow/pull/369](https://github.com/dmlc/mshadow/pull/369) to address memory issues in mxnet exit.

When TensorContainer's destructor becomes noexcept(false), classes that reference it also become noexcept(false) implicitly in destruction.

If inherited class's destructor is noexcept(false) and its base class has a virtual destructor, then base class's destructor should also be added noexcept(false) to successfully compile.