### PR TITLE
[rabit harden] fix model recovery tests failures 

### DIFF
--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -25,7 +25,7 @@ namespace dmlc {
 class Spinlock {
  public:
 #ifdef _MSC_VER
-    Spinlock() {
+  Spinlock() {
     lock_.clear();
   }
 #else

--- a/include/dmlc/concurrency.h
+++ b/include/dmlc/concurrency.h
@@ -13,6 +13,7 @@
 #include <queue>
 #include <mutex>
 #include <vector>
+#include <utility>
 #include <condition_variable>
 #include "dmlc/base.h"
 
@@ -24,7 +25,7 @@ namespace dmlc {
 class Spinlock {
  public:
 #ifdef _MSC_VER
-  Spinlock() {
+    Spinlock() {
     lock_.clear();
   }
 #else

--- a/include/dmlc/memory.h
+++ b/include/dmlc/memory.h
@@ -7,6 +7,8 @@
 #define DMLC_MEMORY_H_
 
 #include <vector>
+#include <memory>
+#include <utility>
 #include "./base.h"
 #include "./logging.h"
 #include "./thread_local.h"

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -25,7 +25,7 @@ struct nullopt_t {
   explicit nullopt_t(int a) {}
 #else
   /*! \brief dummy constructor */
-  constexpr nullopt_t(int a) {}
+  explicit nullopt_t(int a) {}
 #endif
 };
 

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -25,7 +25,7 @@ struct nullopt_t {
   explicit nullopt_t(int a) {}
 #else
   /*! \brief dummy constructor */
-  explicit nullopt_t(int a) {}
+  constexpr explicit nullopt_t(int a) {}
 #endif
 };
 

--- a/include/dmlc/thread_group.h
+++ b/include/dmlc/thread_group.h
@@ -11,6 +11,8 @@
 #include <dmlc/logging.h>
 #include <string>
 #include <mutex>
+#include <utility>
+#include <memory>
 #include <set>
 #include <thread>
 #include <unordered_set>

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -20,7 +20,7 @@ if [ ${TASK} == "unittest_gtest" ]; then
     make -f scripts/packages.mk gtest
     if [ ${TRAVIS_OS_NAME} != "osx" ]; then
         echo "USE_S3=1" >> config.mk
-        echo "export CXX = g++-7" >> config.mk
+        echo "export CXX = g++-4.8" >> config.mk
     else
         echo "USE_S3=0" >> config.mk
         echo "USE_OPENMP=0" >> config.mk

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -20,7 +20,7 @@ if [ ${TASK} == "unittest_gtest" ]; then
     make -f scripts/packages.mk gtest
     if [ ${TRAVIS_OS_NAME} != "osx" ]; then
         echo "USE_S3=1" >> config.mk
-        echo "export CXX = g++-4.8" >> config.mk
+        echo "export CXX = g++-7" >> config.mk
     else
         echo "USE_S3=0" >> config.mk
         echo "USE_OPENMP=0" >> config.mk

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -8,7 +8,6 @@ import subprocess
 import logging
 from threading import Thread
 from . import tracker
-import pdb
 
 def exec_cmd(cmd, role, taskid, pass_env):
     """Execute the command line command."""
@@ -25,9 +24,9 @@ def exec_cmd(cmd, role, taskid, pass_env):
     num_retry = env.get('DMLC_NUM_ATTEMPT', 0)
 
     #overwrite default num of retry with commandline value
-    for parm in cmd:
-        if parm.startswith('DMLC_NUM_ATTEMPT'):
-            num_retry = int(parm.split('=')[1])
+    for param in cmd:
+        if param.startswith('DMLC_NUM_ATTEMPT'):
+            num_retry = int(param.split('=')[1])
     logging.debug('num of retry %d',num_retry)
 
     while True:
@@ -54,7 +53,7 @@ def exec_cmd(cmd, role, taskid, pass_env):
             if os.name == 'nt':
                 sys.exit(-1)
             else:
-                raise RuntimeError('Get nonzero return code=%d on %s' % (ret, cmd))
+                raise RuntimeError('Get nonzero return code=%d on %s %s' % (ret, cmd, env))
 
 
 def submit(args):


### PR DESCRIPTION
Rabit tests has been failing since early 2018. ![screenshot from 2019-03-06 19-56-19](https://user-images.githubusercontent.com/1184534/53931466-1f654980-404a-11e9-8599-7550af82ffbf.png)

According to @tqchen this is largely due to tracker semantic issue. As I have been working on enable checkpoint at rabit could work on GCP.  I need to make sure those tests can pass before introducing extra features. 

Here is some of my observations to tracker/rabit interaction. 

- Rabit mock relay on command line to pass on which number of trail it runs on as a factor to simulate worker crash (exit(-2)). When worker actually dead and local tracker subprocess exit. worker were restarted without update **rabit_num_trail** setting. (this is essentially infinite loop of crash)

- Total number of restart a worker in local tracker is controlled by **DMLC_NUM_ATTEMPT**, by default it was set to zero. So when a rabit unit test kick off like following, total number of retry is still set to zero (no retry) and local tracker throw exception.

- Rabit Init has a overwrite code which use value from **DMLC_NUM_ATTEMPT** to overwrite value from **rabit_num_trial**. I am not sure why since num_trail is incremental and DMLC_NUM_ATTEMPT if set to greater than 0 will skip most of mock failures.

`
model_recover_10_10k: ../dmlc-core/tracker/dmlc-submit --cluster local --num-workers=2 model_recover 10000 mock=0,0,1,0 mock=1,1,1,0 rabit_num_trial=0 DMLC_NUM_ATTEMPT=10
`