### PR TITLE
Support std::exception in threadediter

### DIFF
--- a/include/dmlc/common.h
+++ b/include/dmlc/common.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <sstream>
 #include <mutex>
+#include <utility>
 #include "./logging.h"
 
 namespace dmlc {
@@ -65,6 +66,11 @@ class OMPException {
     try {
       f(params...);
     } catch (dmlc::Error &ex) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!omp_exception_) {
+        omp_exception_ = std::current_exception();
+      }
+    } catch (std::exception &ex) {
       std::lock_guard<std::mutex> lock(mutex_);
       if (!omp_exception_) {
         omp_exception_ = std::current_exception();

--- a/include/dmlc/threadediter.h
+++ b/include/dmlc/threadediter.h
@@ -371,7 +371,7 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
         }
         if (notify)
           consumer_cond_.notify_all();
-      } catch (dmlc::Error &e) {
+      } catch (std::exception &e) {
         // Shouldn't throw exception in destructor
         DCHECK(producer_sig_ != kDestroy);
         {
@@ -461,8 +461,13 @@ template <typename DType> inline void ThreadedIter<DType>::ThrowExceptionIfSet(v
       tmp_exception = iter_exception_;
     }
   }
-  if (tmp_exception)
-    std::rethrow_exception(tmp_exception);
+  if (tmp_exception) {
+    try {
+      std::rethrow_exception(tmp_exception);
+    } catch (std::exception& exc) {
+      LOG(FATAL) << exc.what();
+    }
+  }
 }
 
 template <typename DType> inline void ThreadedIter<DType>::ClearException(void) {


### PR DESCRIPTION
Adding support for std::exception in threadediter. This will catch std::exceptions and opencv exceptions and fail gracefully instead of terminating the process. 
This also fixes https://github.com/apache/incubator-mxnet/issues/10393
Fixes: https://github.com/apache/incubator-mxnet/issues/12280, although this is closed this issue is not yet fixed

@zhreshold @hcho3 