### PR TITLE
Add noexcept in DataIter, InputSplit

### DIFF
--- a/include/dmlc/common.h
+++ b/include/dmlc/common.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <sstream>
 #include <mutex>
+#include <utility>
 #include "./logging.h"
 
 namespace dmlc {

--- a/include/dmlc/data.h
+++ b/include/dmlc/data.h
@@ -56,7 +56,7 @@ template<typename DType>
 class DataIter {
  public:
   /*! \brief destructor */
-  virtual ~DataIter(void) {}
+  virtual ~DataIter(void) DMLC_THROW_EXCEPTION {}
   /*! \brief set before first of the item */
   virtual void BeforeFirst(void) = 0;
   /*! \brief move to next item */

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -231,7 +231,7 @@ class InputSplit {
     return NextChunk(out_chunk);
   }
   /*! \brief destructor*/
-  virtual ~InputSplit(void) {}
+  virtual ~InputSplit(void) DMLC_THROW_EXCEPTION {}
   /*!
    * \brief reset the Input split to a certain part id,
    *  The InputSplit will be pointed to the head of the new specified segment.


### PR DESCRIPTION
This PR applies #506 to the master branch. After this PR is merged, we should be able to address #507, i.e. MXNet will be able to point to the latest dmlc-core again.