### PR TITLE
Support RISC-V cross compilation

### DIFF
--- a/include/dmlc/build_config.h
+++ b/include/dmlc/build_config.h
@@ -21,7 +21,8 @@
 #if (defined(__GNUC__) && !defined(__MINGW32__)\
      && !defined(__sun) && !defined(__SVR4)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
-     && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)
+     && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
+     && !defined(__RISCV__)
   #define DMLC_LOG_STACK_TRACE 1
   #define DMLC_LOG_STACK_TRACE_SIZE 10
   #define DMLC_EXECINFO_H <execinfo.h>

--- a/include/dmlc/endian.h
+++ b/include/dmlc/endian.h
@@ -14,7 +14,7 @@
 #else
   #if defined(__APPLE__) || defined(_WIN32)
     #define DMLC_LITTLE_ENDIAN 1
-  #elif defined(__GLIBC__) || defined(__ANDROID__)
+  #elif defined(__GLIBC__) || defined(__ANDROID__) || defined(__RISCV__)
     #include <endian.h>
     #define DMLC_LITTLE_ENDIAN (__BYTE_ORDER == __LITTLE_ENDIAN)
   #elif defined(__FreeBSD__)


### PR DESCRIPTION
This allows TVM to build using a RISC-V GCC toolchain (https://github.com/rv8-io/musl-riscv-toolchain)