### PR TITLE
[rabit harden] address subprocess exit deadlock

### DIFF
--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -68,7 +68,8 @@ def submit(args):
                 role = 'worker'
             else:
                 role = 'server'
-            # the problem of
+
+            # the problem of https://bugs.python.org/issue20318
             # using thread means branch from same process shared by all threads
             # observed issue of subprocess call stuck and not return when rabit exit(-2)
             # exec_cmd use subprocess which branch from each worker process chenqin

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -62,15 +62,25 @@ def submit(args):
         nserver: number of server nodes to start up
         envs: enviroment variables to be added to the starting programs
         """
-        procs = {}
+        procs = []
         for i in range(nworker + nserver):
             if i < nworker:
                 role = 'worker'
             else:
                 role = 'server'
-            procs[i] = Thread(target=exec_cmd, args=(args.command, args.local_num_attempt, role, i, envs))
-            procs[i].setDaemon(True)
-            procs[i].start()
+            # the problem of
+            # using thread means branch from same process shared by all threads
+            # observed issue of subprocess call stuck and not return when rabit exit(-2)
+            # exec_cmd use subprocess which branch from each worker process chenqin
+            child = os.fork()
+            if child:
+                procs.append(child)
+            else:
+                exec_cmd(args.command, args.local_num_attempt, role, i, envs)
+                return
+
+        for child in procs:
+            os.waitpid(child, 0)
 
     # call submit, with nslave, the commands to run each job and submit function
     tracker.submit(args.num_workers, args.num_servers, fun_submit=mthread_submit,


### PR DESCRIPTION
https://bugs.python.org/issue20318 Caused rabit test hang and timeout from time to time. As python community has no plan to fix in 2.7. We should use process to replace thread to run each rabit worker.