### PR TITLE
[python3] use python3 dmlc tracker in rabit tests

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # pylint: disable=protected-access, unused-variable, locally-disabled, len-as-condition
 """Lint helper to generate lint summary of source.
 

--- a/tracker/dmlc-submit
+++ b/tracker/dmlc-submit
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))

--- a/tracker/dmlc_tracker/kubernetes.py
+++ b/tracker/dmlc_tracker/kubernetes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 DMLC submission script by kubernetes
 

--- a/tracker/dmlc_tracker/launcher.py
+++ b/tracker/dmlc_tracker/launcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # pylint: disable=invalid-name
 """The container launcher script that launches DMLC with the right env variable."""
 import glob

--- a/tracker/dmlc_tracker/mesos.py
+++ b/tracker/dmlc_tracker/mesos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 DMLC submission script by mesos
 

--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 DMLC submission script by ssh
 


### PR DESCRIPTION
upgrade to dmlc-submit to python3 as alternative to https://github.com/dmlc/dmlc-core/pull/524
