### PR TITLE
stringstream default behaviour will lose precision

### DIFF
--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -1014,7 +1014,7 @@ class FieldEntry<float> : public FieldEntryNumeric<FieldEntry<float>, float> {
     }
   }
 
-  protected:
+ protected:
   // print the value
   virtual void PrintValue(std::ostream &os, float value) const {  // NOLINT(*)
     os << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
@@ -1053,7 +1053,7 @@ class FieldEntry<double>
     }
   }
 
-  protected:
+ protected:
   // print the value
   virtual void PrintValue(std::ostream &os, double value) const {  // NOLINT(*)
     os << std::setprecision(std::numeric_limits<double>::max_digits10) << value;

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <stdexcept>
 #include <iostream>
+#include <iomanip>
 #include <cerrno>
 #include "./base.h"
 #include "./json.h"
@@ -1012,6 +1013,12 @@ class FieldEntry<float> : public FieldEntryNumeric<FieldEntry<float>, float> {
       throw dmlc::ParamError(os.str());
     }
   }
+
+  protected:
+  // print the value
+  virtual void PrintValue(std::ostream &os, float value) const {  // NOLINT(*)
+    os << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+  }
 };
 
 // specialize define for double. Uses stod for platform independent handling of
@@ -1044,6 +1051,12 @@ class FieldEntry<double>
          << value.substr(pos) << "\'";
       throw dmlc::ParamError(os.str());
     }
+  }
+
+  protected:
+  // print the value
+  virtual void PrintValue(std::ostream &os, double value) const {  // NOLINT(*)
+    os << std::setprecision(std::numeric_limits<double>::max_digits10) << value;
   }
 };
 #endif  // DMLC_USE_CXX11


### PR DESCRIPTION
Currently, when we accept  float / double values, we will use stringstream. However, the default behaviour of stringstream will lose precision of float / double.

For example:

```cpp
int main() {
    double d = 0.1234567890987654;
    std::stringstream ss;
    ss << d;
    std::cout << ss.str() << "\n";
    ss.str("");
    ss << std::setprecision(std::numeric_limits<double>::max_digits10) << d;
    std::cout << ss.str() << "\n";
}
```

output:
0.123457
0.1234567890987654

We could see we will lose precision if we don't set precision. This PR fix this issue. 

Background: It is found in TVM when we pass Python's double value to TVM's NNVM, then get back to Python, finally we get incorrect result.