### PR TITLE
Do not throw exception in destructor of dmlc::TemporaryDirectory

### DIFF
--- a/src/io/filesys.cc
+++ b/src/io/filesys.cc
@@ -37,8 +37,10 @@ void TemporaryDirectory::RecursiveDelete(const std::string &path) {
     if (info.type == io::FileType::kDirectory) {
       RecursiveDelete(info.path.name);
     } else {
-      CHECK_EQ(std::remove(info.path.name.c_str()), 0)
-          << "Couldn't remove file " << info.path.name;
+      if (std::remove(info.path.name.c_str()) != 0) {
+        LOG(INFO) << "Couldn't remove file " << info.path.name
+                  << "; you may want to remove it manually";
+      }
     }
   }
 #if _WIN32
@@ -51,8 +53,9 @@ void TemporaryDirectory::RecursiveDelete(const std::string &path) {
       LOG(INFO) << "Successfully deleted temporary directory " << path;
     }
   } else {
-    LOG(FATAL) << "~TemporaryDirectory(): "
-               << "Could not remove temporary directory " << path;
+    LOG(INFO) << "~TemporaryDirectory(): "
+              << "Could not remove temporary directory " << path
+              << "; you may want to remove it manually";
   }
 }
 }  // namespace dmlc


### PR DESCRIPTION
Throwing exception out of the destructor of `TemporaryDirectory` causes the Google Tests application for XGBoost to crash. Throwing exceptions inside a destructor is dangerous and may cause the application to terminate. See https://stackoverflow.com/questions/130117/throwing-exceptions-out-of-a-destructor.

Fixes dmlc/xgboost#4471

Fix. Display warnings when temporary files fail to delete.