### PR TITLE
Allow resizing of buffer on local filesystem

### DIFF
--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -115,6 +115,14 @@ class SeekStream: public Stream {
   /*! \brief tell the position of the stream */
   virtual size_t Tell(void) = 0;
   /*!
+   * \brief Resize internal I/O buffer. Only applicable for local filesystem.
+   * \param bufsize new buffer size
+   * \return whether buffer was successfully resized
+   */
+  virtual bool ResizeIOBuffer(size_t bufsize) {
+    return false;
+  }
+  /*!
    * \brief generic factory function
    *  create an SeekStream for read only,
    *  the stream will close the underlying files upon deletion

--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -38,6 +38,9 @@ class FileStream : public SeekStream {
     CHECK(std::fwrite(ptr, 1, size, fp_) == size)
         << "FileStream.Write incomplete";
   }
+  virtual bool ResizeIOBuffer(size_t bufsize) {
+    return (std::setvbuf(fp_, NULL, _IOFBF, bufsize) == 0);
+  }
   virtual void Seek(size_t pos) {
 #ifndef _MSC_VER
     CHECK(!std::fseek(fp_, static_cast<long>(pos), SEEK_SET));  // NOLINT(*)


### PR DESCRIPTION
I/O Streams for local file systems (`FileStream::Read()` / `FileStream::Write()`) use buffered I/O, where the default buffer size is given by `BUFSIZ`. However, `BUFSIZ` may not necessarily provide an optimal value for the buffer; often it may be too small. This PR will add the function `ResizeIOBuffer()` to allow the user to increase the buffer size, potentially improving performance on volumes mounted over the network.

Notes:
* `ResizeIOBuffer()` uses [`std::setvbuf()`](https://en.cppreference.com/w/cpp/io/c/setvbuf).
* For other file systems, `ResizeIOBuffer()` is a no-op.