### PR TITLE
hide debug logging by default

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -138,8 +138,8 @@ inline bool DebugLoggingEnabled() {
         state = -1;
       }
     } else {
-      // by default always enable debug logging.
-      state = 1;
+      // by default hide debug logging.
+      state = -1;
     }
   }
   return state == 1;


### PR DESCRIPTION
Given many users want to compile under debugging mode. It can be annoying to see all the debug logs by default, choose to not show them by default