### PR TITLE
support set/get configuration in tracker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ NOLINT_FILES = --exclude_path include/dmlc/concurrentqueue.h include/dmlc/blocki
 
 # this is the common build script for dmlc lib
 export LDFLAGS= -pthread -lm
-export CFLAGS = -O3 -g -Wall -Wno-unknown-pragmas -Iinclude
+export CFLAGS = -O3 -Wall -Wno-unknown-pragmas -Iinclude
 ifeq ($(USE_GNU11), 1)
 	CFLAGS += -std=gnu++11
 else
-	CFLAGS += -std=c++11
+	CFLAGS += -std=c++0x
 endif
 LDFLAGS+= $(DMLC_LDFLAGS) $(ADD_LDFLAGS)
 CFLAGS+= $(DMLC_CFLAGS) $(ADD_CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ NOLINT_FILES = --exclude_path include/dmlc/concurrentqueue.h include/dmlc/blocki
 
 # this is the common build script for dmlc lib
 export LDFLAGS= -pthread -lm
-export CFLAGS = -O3 -Wall -Wno-unknown-pragmas -Iinclude
+export CFLAGS = -O3 -g -Wall -Wno-unknown-pragmas -Iinclude
 ifeq ($(USE_GNU11), 1)
 	CFLAGS += -std=gnu++11
 else
-	CFLAGS += -std=c++0x
+	CFLAGS += -std=c++11
 endif
 LDFLAGS+= $(DMLC_LDFLAGS) $(ADD_LDFLAGS)
 CFLAGS+= $(DMLC_CFLAGS) $(ADD_CFLAGS)

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -68,7 +68,8 @@ def submit(args):
                 role = 'worker'
             else:
                 role = 'server'
-            # the problem of
+
+            # the problem of https://bugs.python.org/issue20318
             # using thread means branch from same process shared by all threads
             # observed issue of subprocess call stuck and not return when rabit exit(-2)
             # exec_cmd use subprocess which branch from each worker process chenqin

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -42,6 +42,7 @@ def exec_cmd(cmd, num_attempt, role, taskid, pass_env):
 
             if num_retry >= 0:
                 cmdline = ' '.join(cmd + ['DMLC_NUM_ATTEMPT=' + str(num_trial)])
+                #cmdline = 'gdb ../../xgboost'
                 continue
             if os.name == 'nt':
                 sys.exit(-1)

--- a/tracker/dmlc_tracker/local.py
+++ b/tracker/dmlc_tracker/local.py
@@ -62,15 +62,25 @@ def submit(args):
         nserver: number of server nodes to start up
         envs: enviroment variables to be added to the starting programs
         """
-        procs = {}
+        procs = []
         for i in range(nworker + nserver):
             if i < nworker:
                 role = 'worker'
             else:
                 role = 'server'
-            procs[i] = Thread(target=exec_cmd, args=(args.command, args.local_num_attempt, role, i, envs))
-            procs[i].setDaemon(True)
-            procs[i].start()
+            # the problem of
+            # using thread means branch from same process shared by all threads
+            # observed issue of subprocess call stuck and not return when rabit exit(-2)
+            # exec_cmd use subprocess which branch from each worker process chenqin
+            child = os.fork()
+            if child:
+                procs.append(child)
+            else:
+                exec_cmd(args.command, args.local_num_attempt, role, i, envs)
+                return
+
+        for child in procs:
+            os.waitpid(child, 0)
 
     # call submit, with nslave, the commands to run each job and submit function
     tracker.submit(args.num_workers, args.num_servers, fun_submit=mthread_submit,

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -271,7 +271,6 @@ class RabitTracker(object):
             if s.cmd == 'set':
                 key = s.sock.recvstr()
                 value = s.sock.recvstr()
-                logging.info(key.strip(), value.strip())
                 configurations[key] = value
                 continue
             if s.cmd == 'get':

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -262,10 +262,22 @@ class RabitTracker(object):
         pending = []
         # lazy initialize tree_map
         tree_map = None
+        # configurations
+        configurations = {}
 
         while len(shutdown) != nslave:
             fd, s_addr = self.sock.accept()
             s = SlaveEntry(fd, s_addr)
+            if s.cmd == 'set':
+                key = s.sock.recvstr()
+                value = s.sock.recvstr()
+                logging.info(key.strip(), value.strip())
+                configurations[key] = value
+                continue
+            if s.cmd == 'get':
+                key = s.sock.recvstr()
+                s.sock.sendstr('none' if configurations[key] is None else configurations[key])
+                continue
             if s.cmd == 'print':
                 msg = s.sock.recvstr()
                 logging.info(msg.strip())

--- a/tracker/dmlc_tracker/tracker.py
+++ b/tracker/dmlc_tracker/tracker.py
@@ -276,7 +276,7 @@ class RabitTracker(object):
                 continue
             if s.cmd == 'get':
                 key = s.sock.recvstr()
-                s.sock.sendstr('none' if configurations[key] is None else configurations[key])
+                s.sock.sendstr(configurations.get(key, 'none'))
                 continue
             if s.cmd == 'print':
                 msg = s.sock.recvstr()


### PR DESCRIPTION
xgb native checkpoint recovery were broken because restart worker run allreduce before loadcheckpoint.
if tracker support set/get shared configuration, we can have native rabit recovery running.

https://github.com/dmlc/xgboost/issues/4250#issuecomment-501023606
