### PR TITLE
Identity is not the same things as equality in Python

### DIFF
--- a/tracker/dmlc_tracker/kubernetes.py
+++ b/tracker/dmlc_tracker/kubernetes.py
@@ -85,7 +85,7 @@ def create_sched_job_manifest( wk_num, ps_num, envs, image,  commands):
     envs.append( client.V1EnvVar( name="DMLC_ROLE", value="scheduler" ))
     name = ""
     for i in envs:
-        if i.name is "DMLC_PS_ROOT_URI":
+        if i.name == "DMLC_PS_ROOT_URI":
             name = i.value
             break
     return create_job_manifest(envs, commands, name, image, None )


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals.

$ __python__
```
>>> name = "DMLC_PS_"
>>> name += "ROOT_URI"
>>> name == "DMLC_PS_ROOT_URI"
True
>>> name is "DMLC_PS_ROOT_URI"
False
```