### PR TITLE
Declare the type name of `int64_t`

### DIFF
--- a/include/dmlc/type_traits.h
+++ b/include/dmlc/type_traits.h
@@ -171,6 +171,7 @@ DMLC_DECLARE_TRAITS(is_floating_point, double, true);
 DMLC_DECLARE_TYPE_NAME(float, "float");
 DMLC_DECLARE_TYPE_NAME(double, "double");
 DMLC_DECLARE_TYPE_NAME(int, "int");
+DMLC_DECLARE_TYPE_NAME(int64_t, "long");
 DMLC_DECLARE_TYPE_NAME(uint32_t, "int (non-negative)");
 DMLC_DECLARE_TYPE_NAME(uint64_t, "long (non-negative)");
 DMLC_DECLARE_TYPE_NAME(std::string, "string");


### PR DESCRIPTION
In MXNet, `dim_t` is the type of some parameters, like [`mx.nd.eye`](https://github.com/apache/incubator-mxnet/blob/master/src/operator/tensor/init_op.h#L84). 

However, `dim_t` couldn't be parsed into a string, since `dim_t` is the alias of `int64_t`, which is not registed by dmlc-core type-traits.

In this PR, I declare the type name of `int64_t`.