### PR TITLE
Add necessary checks and definitions to build on Hexagon

### DIFF
--- a/include/dmlc/build_config.h
+++ b/include/dmlc/build_config.h
@@ -22,7 +22,7 @@
      && !defined(__sun) && !defined(__SVR4)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
-     && !defined(__RISCV__)
+     && !defined(__RISCV__) && !defined(__hexagon__)
   #define DMLC_LOG_STACK_TRACE 1
   #define DMLC_LOG_STACK_TRACE_SIZE 10
   #define DMLC_EXECINFO_H <execinfo.h>

--- a/include/dmlc/endian.h
+++ b/include/dmlc/endian.h
@@ -21,7 +21,7 @@
   #elif defined(__FreeBSD__) || defined(__OpenBSD__)
     #include <sys/endian.h>
     #define DMLC_LITTLE_ENDIAN (_BYTE_ORDER == _LITTLE_ENDIAN)
-  #elif defined(__EMSCRIPTEN__)
+  #elif defined(__EMSCRIPTEN__) || defined(__hexagon__)
     #define DMLC_LITTLE_ENDIAN 1
   #elif defined(__sun)
     #include <sys/isa_defs.h>


### PR DESCRIPTION
Hexagon is a 32-bit little-endian, and at the moment we don't support stack traces.