### PR TITLE
Fix data race and thread leak in ThreadedIter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
   - env: TASK=cmake_test
     os: linux
     python: '3.6'
+  - env: TASK=sanitizer_test
+    os: linux
+    python: '3.6'
   - env: TASK=unittest_gtest
     language: ruby
     os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ dmlccore_option(USE_CXX14_IF_AVAILABLE "Build with C++14 if the compiler support
 dmlccore_option(GOOGLE_TEST "Build google tests" OFF)
 dmlccore_option(INSTALL_DOCUMENTATION "Install documentation" OFF)
 dmlccore_option(DMLC_FORCE_SHARED_CRT "Build with dynamic CRT on Windows (/MD)" OFF)
+dmlccore_option(DMLC_USE_SANITIZER "Use santizer flags; to specify a custom path for sanitizers, set this variable a value that's not ON or OFF" OFF)
+set(DMLC_ENABLED_SANITIZERS "address" "leak" CACHE STRING
+  "Semicolon separated list of sanitizer names. E.g 'address;leak'. Supported sanitizers are
+  address, leak and thread.")
 
 # include path
 set(INCLUDE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -28,6 +32,15 @@ set(INCLUDE_DMLC_DIR "${INCLUDE_ROOT}/dmlc")
 # include_directories("${INCLUDE_ROOT}")
 
 set(dmlccore_LINKER_LIBS "")
+
+# Sanitizer
+if (DMLC_USE_SANITIZER)
+  # Older CMake versions have had troubles with Sanitizer
+  cmake_minimum_required(VERSION 3.12)
+  include(cmake/Sanitizer.cmake)
+  enable_sanitizers("${DMLC_ENABLED_SANITIZERS}")
+endif (DMLC_USE_SANITIZER)
+
 # HDFS configurations
 if(USE_HDFS)
  find_package(HDFS REQUIRED)

--- a/cmake/Modules/FindASan.cmake
+++ b/cmake/Modules/FindASan.cmake
@@ -1,0 +1,13 @@
+set(ASan_LIB_NAME ASan)
+
+find_library(ASan_LIBRARY
+  NAMES libasan.so libasan.so.4 libasan.so.3 libasan.so.2 libasan.so.1 libasan.so.0
+  PATHS ${DMLC_USE_SANITIZER} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ASan DEFAULT_MSG
+  ASan_LIBRARY)
+
+mark_as_advanced(
+  ASan_LIBRARY
+  ASan_LIB_NAME)

--- a/cmake/Modules/FindLSan.cmake
+++ b/cmake/Modules/FindLSan.cmake
@@ -1,0 +1,13 @@
+set(LSan_LIB_NAME lsan)
+
+find_library(LSan_LIBRARY
+  NAMES liblsan.so liblsan.so.0 liblsan.so.0.0.0
+  PATHS ${DMLC_USE_SANITIZER} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LSan DEFAULT_MSG
+  LSan_LIBRARY)
+
+mark_as_advanced(
+  LSan_LIBRARY
+  LSan_LIB_NAME)

--- a/cmake/Modules/FindTSan.cmake
+++ b/cmake/Modules/FindTSan.cmake
@@ -1,0 +1,13 @@
+set(TSan_LIB_NAME tsan)
+
+find_library(TSan_LIBRARY
+  NAMES libtsan.so libtsan.so.0 libtsan.so.0.0.0
+  PATHS ${DMLC_USE_SANITIZER} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(TSan DEFAULT_MSG
+  TSan_LIBRARY)
+
+mark_as_advanced(
+  TSan_LIBRARY
+  TSan_LIB_NAME)

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -1,0 +1,58 @@
+# Set appropriate compiler and linker flags for sanitizers.
+#
+# Usage of this module:
+#  enable_sanitizers("address;leak")
+
+# Add flags
+macro(enable_sanitizer santizer)
+  if(${santizer} MATCHES "address")
+    find_package(ASan REQUIRED)
+    set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=address")
+    link_libraries(${ASan_LIBRARY})
+
+  elseif(${santizer} MATCHES "thread")
+    find_package(TSan REQUIRED)
+    set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=thread")
+    link_libraries(${TSan_LIBRARY})
+
+  elseif(${santizer} MATCHES "leak")
+    find_package(LSan REQUIRED)
+    set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=leak")
+    link_libraries(${LSan_LIBRARY})
+
+  else()
+    message(FATAL_ERROR "Santizer ${santizer} not supported.")
+  endif()
+endmacro()
+
+macro(enable_sanitizers SANITIZERS)
+  # Check sanitizers compatibility.
+  # Idealy, we should use if(san IN_LIST SANITIZERS) ... endif()
+  # But I haven't figure out how to make it work.
+  foreach ( _san ${SANITIZERS} )
+    string(TOLOWER ${_san} _san)
+    if (_san MATCHES "thread")
+      if (${_use_other_sanitizers})
+        message(FATAL_ERROR
+          "thread sanitizer is not compatible with ${_san} sanitizer.")
+      endif()
+      set(_use_thread_sanitizer 1)
+    else ()
+      if (${_use_thread_sanitizer})
+        message(FATAL_ERROR
+          "${_san} sanitizer is not compatible with thread sanitizer.")
+      endif()
+      set(_use_other_sanitizers 1)
+    endif()
+  endforeach()
+
+  message("Sanitizers: ${SANITIZERS}")
+
+  foreach( _san ${SANITIZERS} )
+    string(TOLOWER ${_san} _san)
+    enable_sanitizer(${_san})
+  endforeach()
+  message("Sanitizers compile flags: ${SAN_COMPILE_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SAN_COMPILE_FLAGS}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${SAN_COMPILE_FLAGS}")
+endmacro()

--- a/include/dmlc/threadediter.h
+++ b/include/dmlc/threadediter.h
@@ -18,10 +18,41 @@
 #include <queue>
 #include <atomic>
 #include <thread>
+#include <utility>
+#include <memory>
 #include "./data.h"
 #include "./logging.h"
 
 namespace dmlc {
+
+/*!
+ * \brief Wrapper class to manage std::thread; uses RAII pattern to automatically
+ *        join std::thread upon destruction
+ */
+class ScopedThread {
+ public:
+  /*!
+   * \brief constructor
+   * \param thread thread to manage
+   */
+  explicit ScopedThread(std::thread thread)
+      : thread_(std::move(thread)) {
+    if (!thread_.joinable()) {
+      throw std::logic_error("No thread");
+    }
+  }
+  // destructor: join upon destruction
+  virtual ~ScopedThread() {
+    thread_.join();
+  }
+  // copy assignment and construction are not allowed
+  ScopedThread(ScopedThread const&) = delete;
+  ScopedThread& operator=(ScopedThread const&) = delete;
+
+ private:
+  std::thread thread_;
+};
+
 /*!
  * \brief a iterator that was backed by a thread
  *  to pull data eagerly from a single producer into a bounded buffer
@@ -80,7 +111,7 @@ class ThreadedIter : public DataIter<DType> {
    */
   explicit ThreadedIter(size_t max_capacity = 8)
       : producer_owned_(NULL),
-        producer_thread_(NULL),
+        producer_thread_(nullptr),
         max_capacity_(max_capacity),
         nwait_consumer_(0),
         nwait_producer_(0),
@@ -183,19 +214,19 @@ class ThreadedIter : public DataIter<DType> {
       free_cells_.push(out_data_);
       out_data_ = NULL;
     }
-    if (producer_sig_ == kDestroy)  return;
+    if (producer_sig_.load(std::memory_order_acquire) == kDestroy)  return;
 
-    producer_sig_ = kBeforeFirst;
-    CHECK(!producer_sig_processed_);
+    producer_sig_.store(kBeforeFirst, std::memory_order_release);
+    CHECK(!producer_sig_processed_.load(std::memory_order_acquire));
     if (nwait_producer_ != 0) {
       producer_cond_.notify_one();
     }
-    CHECK(!producer_sig_processed_);
+    CHECK(!producer_sig_processed_.load(std::memory_order_acquire));
     // wait until the request has been processed
     consumer_cond_.wait(lock, [this]() {
-        return producer_sig_processed_;
+        return producer_sig_processed_.load(std::memory_order_acquire);
       });
-    producer_sig_processed_ = false;
+    producer_sig_processed_.store(false, std::memory_order_release);
     bool notify = nwait_producer_ != 0 && !produce_end_;
     lock.unlock();
     // notify producer, in case they are waiting for the condition.
@@ -217,11 +248,11 @@ class ThreadedIter : public DataIter<DType> {
   /*! \brief producer class */
   Producer *producer_owned_;
   /*! \brief signal to producer */
-  Signal producer_sig_;
+  std::atomic<Signal> producer_sig_;
   /*! \brief whether the special signal other than kProduce is procssed */
-  bool producer_sig_processed_;
+  std::atomic<bool> producer_sig_processed_;
   /*! \brief thread that runs the producer */
-  std::thread *producer_thread_;
+  std::unique_ptr<ScopedThread> producer_thread_;
   /*! \brief whether produce ends */
   std::atomic<bool> produce_end_;
   /*! \brief maximum queue size */
@@ -232,7 +263,7 @@ class ThreadedIter : public DataIter<DType> {
   std::mutex mutex_exception_;
   /*! \brief number of consumer waiting */
   unsigned nwait_consumer_;
-  /*! \brief number of consumer waiting */
+  /*! \brief number of producer waiting */
   unsigned nwait_producer_;
   /*! \brief conditional variable for producer thread */
   std::condition_variable producer_cond_;
@@ -250,19 +281,17 @@ class ThreadedIter : public DataIter<DType> {
 
 // implementation of functions
 template <typename DType> inline void ThreadedIter<DType>::Destroy(void) {
-  if (producer_thread_ != NULL) {
+  if (producer_thread_) {
     {
       // lock the mutex
       std::lock_guard<std::mutex> lock(mutex_);
       // send destroy signal
-      producer_sig_ = kDestroy;
+      producer_sig_.store(kDestroy, std::memory_order_release);
       if (nwait_producer_ != 0) {
         producer_cond_.notify_one();
       }
     }
-    producer_thread_->join();
-    delete producer_thread_;
-    producer_thread_ = NULL;
+    producer_thread_.reset(nullptr);
   }
   // end of critical region
   // now the slave thread should exit
@@ -300,8 +329,8 @@ Init(Producer *producer, bool pass_ownership) {
 template <typename DType>
 inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
                                       std::function<void()> beforefirst) {
-  producer_sig_ = kProduce;
-  producer_sig_processed_ = false;
+  producer_sig_.store(kProduce, std::memory_order_release);
+  producer_sig_processed_.store(false, std::memory_order_release);
   produce_end_.store(false, std::memory_order_release);
   ClearException();
   // procedure running in prodcuer
@@ -315,7 +344,7 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
           std::unique_lock<std::mutex> lock(mutex_);
           ++this->nwait_producer_;
           producer_cond_.wait(lock, [this]() {
-            if (producer_sig_ == kProduce) {
+            if (producer_sig_.load(std::memory_order_acquire) == kProduce) {
               bool ret = !produce_end_.load(std::memory_order_acquire)
                          && (queue_.size() < max_capacity_ ||
                              free_cells_.size() != 0);
@@ -325,12 +354,12 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
             }
           });
           --this->nwait_producer_;
-          if (producer_sig_ == kProduce) {
+          if (producer_sig_.load(std::memory_order_acquire) == kProduce) {
             if (free_cells_.size() != 0) {
               cell = free_cells_.front();
               free_cells_.pop();
             }
-          } else if (producer_sig_ == kBeforeFirst) {
+          } else if (producer_sig_.load(std::memory_order_acquire) == kBeforeFirst) {
             // reset the producer
             beforefirst();
             // cleanup the queue
@@ -340,17 +369,18 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
             }
             // reset the state
             produce_end_.store(false, std::memory_order_release);
-            producer_sig_processed_ = true;
-            producer_sig_ = kProduce;
+            producer_sig_processed_.store(true, std::memory_order_release);
+            producer_sig_.store(kProduce, std::memory_order_release);
             // notify consumer that all the process as been done.
             lock.unlock();
             consumer_cond_.notify_all();
             continue;
           } else {
             // destroy the thread
-            DCHECK(producer_sig_ == kDestroy);
-            producer_sig_processed_ = true;
+            DCHECK(producer_sig_.load(std::memory_order_acquire) == kDestroy);
+            producer_sig_processed_.store(true, std::memory_order_release);
             produce_end_.store(true, std::memory_order_release);
+            lock.unlock();
             consumer_cond_.notify_all();
             return;
           }
@@ -375,7 +405,7 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
           consumer_cond_.notify_all();
       } catch (std::exception &e) {
         // Shouldn't throw exception in destructor
-        DCHECK(producer_sig_ != kDestroy);
+        DCHECK(producer_sig_.load(std::memory_order_acquire) != kDestroy);
         {
           std::lock_guard<std::mutex> lock(mutex_exception_);
           if (!iter_exception_) {
@@ -385,16 +415,16 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
         bool next_notify = false;
         {
           std::unique_lock<std::mutex> lock(mutex_);
-          if (producer_sig_ == kBeforeFirst) {
+          if (producer_sig_.load(std::memory_order_acquire) == kBeforeFirst) {
             while (queue_.size() != 0) {
               free_cells_.push(queue_.front());
               queue_.pop();
             }
             produce_end_.store(true, std::memory_order_release);
-            producer_sig_processed_ = true;
+            producer_sig_processed_.store(true, std::memory_order_release);
             lock.unlock();
             consumer_cond_.notify_all();
-          } else if (producer_sig_ == kProduce) {
+          } else if (producer_sig_.load(std::memory_order_acquire) == kProduce) {
             produce_end_.store(true, std::memory_order_release);
             next_notify = nwait_consumer_ != 0;
             lock.unlock();
@@ -406,16 +436,16 @@ inline void ThreadedIter<DType>::Init(std::function<bool(DType **)> next,
       }
     }
   };
-  producer_thread_ = new std::thread(producer_fun);
+  producer_thread_.reset(new ScopedThread{std::thread(producer_fun)});
 }
 
 template <typename DType>
 inline bool ThreadedIter<DType>::Next(DType **out_dptr) {
-  if (producer_sig_ == kDestroy)
+  if (producer_sig_.load(std::memory_order_acquire) == kDestroy)
     return false;
   ThrowExceptionIfSet();
   std::unique_lock<std::mutex> lock(mutex_);
-  CHECK(producer_sig_ == kProduce)
+  CHECK(producer_sig_.load(std::memory_order_acquire) == kProduce)
       << "Make sure you call BeforeFirst not inconcurrent with Next!";
   ++nwait_consumer_;
   consumer_cond_.wait(lock,

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -52,8 +52,8 @@ fi
 if [ ${TASK} == "sanitizer_test" ]; then
     rm -rf build
     mkdir build && cd build
-    cmake .. -DGOOGLE_TEST=ON -DUSE_SANITIZER=ON \
-             -DENABLED_SANITIZERS="thread" -DCMAKE_BUILD_TYPE=Debug ..
+    cmake .. -DGOOGLE_TEST=ON -DDMLC_USE_SANITIZER=ON \
+             -DDMLC_ENABLED_SANITIZERS="thread" -DCMAKE_BUILD_TYPE=Debug ..
     make -j2
     cd ..
     ./build/test/unittest/dmlc_unit_tests || true   # For now just display sanitizer errors

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -49,6 +49,16 @@ if [ ${TASK} == "cmake_test" ]; then
     ./build/test/unittest/dmlc_unit_tests
 fi
 
+if [ ${TASK} == "sanitizer_test" ]; then
+    rm -rf build
+    mkdir build && cd build
+    cmake .. -DGOOGLE_TEST=ON -DUSE_SANITIZER=ON \
+             -DENABLED_SANITIZERS="thread" -DCMAKE_BUILD_TYPE=Debug ..
+    make -j2
+    cd ..
+    ./build/test/unittest/dmlc_unit_tests || true   # For now just display sanitizer errors
+fi
+
 if [ ${TASK} == "s390x_test" ]; then
     # Run unit tests inside emulated s390x Docker container (uses QEMU transparently).
     # This should help us achieve compatibility with big endian targets.

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -5,7 +5,7 @@ int main(void) {
   LOG(ERROR) << "error";
   try {
     LOG(FATAL)<<'a'<<11<<33;
-  } catch (dmlc::Error e) {
+  } catch (dmlc::Error& e) {
     LOG(INFO) << "catch " << e.what();
   }
   CHECK(2!=3) << "test";


### PR DESCRIPTION
Fixes #550

* **Prevent "thread leak"**: Wrap `std::thread*` with `std::unique_ptr<>` and `ScopedThread` so that we can automatically `join()` a thread whenever an exception is thrown. Do not use raw pointer to store the thread, as it's not exception-safe.

* **Eliminate data races in producer signals**: Make `producer_sig_processed_` and `producer_sig_` atomic because
  1) Multiple threads access these variables;
  2) The variables are often used without a lock.
 
  Furthermore, we use `.store(*, std::memory_order_release)` and `.load(std::memory_order_acquire)` so that a write from one thread is guaranteed to be visible from another thread. See [Release-Acquire Ordering](https://en.cppreference.com/w/cpp/atomic/memory_order#Release-Acquire_ordering).

* Enable building dmlc-core with Sanitizer. For example, to use Thread Sanitizer, run:
```
cmake .. -DGOOGLE_TEST=ON -DDMLC_USE_SANITIZER=ON \
         -DDMLC_ENABLED_SANITIZERS="thread" -DCMAKE_BUILD_TYPE=Debug ..
```

cc @larroy @jermainewang 