### PR TITLE
Remove throw spec from omp.h for clang

### DIFF
--- a/include/dmlc/omp.h
+++ b/include/dmlc/omp.h
@@ -11,7 +11,7 @@
 #include <omp.h>
 #else
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) && defined (__clang__)
 #undef __GOMP_NOTHROW
 #define __GOMP_NOTHROW
 #elif defined(__cplusplus)


### PR DESCRIPTION
This fixes compilation with OMP using the Clang compiler.