### PR TITLE
Fix MXNet amalgamation

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -278,7 +278,7 @@ inline const char* BeginPtr(const std::string &str) {
 /* If fopen64 is not defined by current machine,
    replace fopen64 with std::fopen. Also determine ability to print stack trace
    for fatal error and define DMLC_LOG_STACK_TRACE if stack trace can be
-   produced. Always keep this #include at the bottom of dmlc/base.h */
+   produced. Always keep this include directive at the bottom of dmlc/base.h */
 #ifdef DMLC_CORE_USE_CMAKE
 #include <dmlc/build_config.h>
 #else


### PR DESCRIPTION
amalgamation is stupied, and will catch `#include` even if it's in comment and cause unexpected error.

@pengzhao-intel @szha 