### PR TITLE
Fix initial-release nvcc v10.1 issue with thread_local.h

### DIFF
--- a/include/dmlc/thread_local.h
+++ b/include/dmlc/thread_local.h
@@ -43,7 +43,9 @@ class ThreadLocalStore {
     static MX_THREAD_LOCAL T* ptr = nullptr;
     if (ptr == nullptr) {
       ptr = new T();
-      Singleton()->RegisterDelete(ptr);
+      // Syntactic work-around for the nvcc of the initial cuda v10.1 release,
+      // which fails to compile 'Singleton()->' below. Fixed in v10.1 update 1.
+      (*Singleton()).RegisterDelete(ptr);
     }
     return ptr;
 #endif


### PR DESCRIPTION
As described in issue https://github.com/apache/incubator-mxnet/issues/16612 and in PR https://github.com/dmlc/xgboost/pull/4223, the nvcc of the initial cuda 10.1 release could at times fail to compile legitimate source code, with the error signature: `cannot call member function XXX without object`.  This PR supplies the same simple syntactic fix identified in the mentioned PR.  Once MXNet is updated to pull in a dmlc-core with this fix, MXNet will compile robustly independent of cuda version.  Thanks @rongou for leading me to this solution.
@larroy @ptrendx