### PR TITLE
Fix include/dmlc/omp.h for clang

### DIFF
--- a/include/dmlc/omp.h
+++ b/include/dmlc/omp.h
@@ -11,7 +11,7 @@
 #include <omp.h>
 #else
 
-#if defined(__ANDROID__) && defined (__clang__)
+#if defined(__ANDROID__) || defined (__clang__)
 #undef __GOMP_NOTHROW
 #define __GOMP_NOTHROW
 #elif defined(__cplusplus)


### PR DESCRIPTION
`__GOMP_NOTHROW` does not make sense when building with clang. I'm not sure why the previous condition assumes `defined(__ANDROID__) && defined (__clang__)`. It doesn't matter if were building for Android or just building with clang.

CC @larroy