### PR TITLE
allow dependencies to override DMLC_LOG_STACK_TRACE

### DIFF
--- a/cmake/build_config.h.in
+++ b/cmake/build_config.h.in
@@ -12,8 +12,12 @@
 #cmakedefine DMLC_EXECINFO_H_PRESENT
 
 #if (defined DMLC_CXXABI_H_PRESENT) && (defined DMLC_EXECINFO_H_PRESENT)
+  #ifndef DMLC_LOG_STACK_TRACE
   #define DMLC_LOG_STACK_TRACE 1
+  #endif
+  #ifndef DMLC_LOG_STACK_TRACE_SIZE
   #define DMLC_LOG_STACK_TRACE_SIZE 10
+  #endif
   #cmakedefine DMLC_EXECINFO_H <${DMLC_EXECINFO_H}>
 #endif
 

--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -23,8 +23,12 @@
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
      && !defined(__RISCV__) && !defined(__hexagon__)
+  #ifndef DMLC_LOG_STACK_TRACE
   #define DMLC_LOG_STACK_TRACE 1
+  #endif
+  #ifndef DMLC_LOG_STACK_TRACE_SIZE
   #define DMLC_LOG_STACK_TRACE_SIZE 10
+  #endif
   #define DMLC_EXECINFO_H <execinfo.h>
 #endif
 


### PR DESCRIPTION
fix the hard-coded DMLC_LOG_STACK_TRACE related variables.