### PR TITLE
Add OpenMP as CMake target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ addons:
       - g++-4.8
   homebrew:
     packages:
+      - gcc@8
       - cmake
       - libomp
       - python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,8 @@ addons:
       - g++-4.8
   homebrew:
     packages:
-      - gcc@7
+      - cmake
+      - libomp
       - python3
     update: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,27 @@ else()
   add_definitions(-DDMLC_USE_AZURE=0)
 endif()
 
+# OpenMP
+if(USE_OPENMP)
+  find_package(OpenMP REQUIRED)
+
+  if(APPLE)
+    # Require CMake 3.12+ for Mac to ensure that OpenMP can be located
+    cmake_minimum_required(VERSION 3.12)
+  endif()
+
+  # For CMake < 3.9, we need to make target OpenMP::OpenMP_CXX ourselves
+  if(NOT TARGET OpenMP::OpenMP_CXX)
+    find_package(Threads REQUIRED)
+    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
+    set_property(TARGET OpenMP::OpenMP_CXX
+                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
+  endif()
+  list(APPEND dmlccore_LINKER_LIBS OpenMP::OpenMP_CXX)
+endif()
+
 if(WIN32 AND (NOT MSVC))  # On Windows, link Shlwapi.lib for non-MSVC compilers
   list(APPEND dmlccore_LINKER_LIBS Shlwapi)
 endif()
@@ -160,22 +181,6 @@ else(MSVC)
   endif()
 endif(MSVC)
 
-if(USE_OPENMP)
-  if(MSVC)
-    set(OPENMP_FOUND ON)
-    set(OpenMP_C_FLAGS "-openmp")
-    set(OpenMP_CXX_FLAGS ${OpenMP_C_FLAGS})
-  else()
-    find_package(OpenMP REQUIRED)
-  endif()
-  if(OPENMP_FOUND)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-  endif()
-endif()
-
 FILE(GLOB SOURCE "src/*.cc")
 FILE(GLOB_RECURSE SOURCE_INCLUDE "include/*")
 list(APPEND SOURCE ${SOURCE_INCLUDE})
@@ -197,7 +202,7 @@ if(USE_AZURE)
 endif()
 
 add_library(dmlc ${SOURCE})
-target_link_libraries(dmlc ${dmlccore_LINKER_LIBS})
+target_link_libraries(dmlc PRIVATE ${dmlccore_LINKER_LIBS})
 target_include_directories(dmlc PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,12 @@ endif()
 
 # OpenMP
 if(USE_OPENMP)
-  find_package(OpenMP REQUIRED)
-
   if(APPLE)
-    # Require CMake 3.12+ for Mac to ensure that OpenMP can be located
-    cmake_minimum_required(VERSION 3.12)
+    # Require CMake 3.16+ for Mac to ensure that OpenMP can be located
+    cmake_minimum_required(VERSION 3.16)
   endif()
+
+  find_package(OpenMP REQUIRED)
 
   # For CMake < 3.9, we need to make target OpenMP::OpenMP_CXX ourselves
   if(NOT TARGET OpenMP::OpenMP_CXX)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,35 +68,35 @@ build_script:
         mkdir build_msvc%ver% &&
         cd build_msvc%ver% &&
         if /i "%generator%" == "Visual Studio 12 2013 Win64" (
-          cmake .. -G"%generator%" -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" &&
+          cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" &&
           msbuild dmlc.sln
         ) else (
-          cmake .. -G"%generator%" -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" -DGOOGLE_TEST=ON &&
+          cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_CONFIGURATION_TYPES="Release;Debug;" -DGOOGLE_TEST=ON &&
           msbuild dmlc.sln
         )
       )
     - if /i "%target%" == "msys2" (
         mkdir build_msys2 &&
         cd build_msys2 &&
-        cmake .. -G"%generator%" -DGOOGLE_TEST=ON &&
+        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON &&
         cmake --build . -- -j2
       )
     - if /i "%target%" == "mingw32" (
         mkdir build_mingw32 &&
         cd build_mingw32 &&
-        cmake .. -G"%generator%" -DGOOGLE_TEST=ON &&
+        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON &&
         cmake --build . -- -j2
       )
     - if /i "%target%" == "mingw" (
         mkdir build_mingw &&
         cd build_mingw &&
-        cmake .. -G"%generator%" -DGOOGLE_TEST=ON &&
+        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON &&
         cmake --build . -- -j2
       )
     - if /i "%target%" == "cygwin" (
         mkdir build_cygwin &&
         cd build_cygwin &&
-        cmake .. -G"%generator%" -DGOOGLE_TEST=ON -DOpenMP_gomp_LIBRARY=-lgomp &&
+        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DOpenMP_gomp_LIBRARY=-lgomp &&
         cmake --build . -- -j2
       )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,7 @@ build_script:
     - if /i "%target%" == "cygwin" (
         mkdir build_cygwin &&
         cd build_cygwin &&
-        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DOpenMP_gomp_LIBRARY=-lgomp &&
+        cmake .. -G"%generator%" -DCMAKE_VERBOSE_MAKEFILE=ON -DGOOGLE_TEST=ON -DOpenMP_gomp_LIBRARY:FILEPATH=-lgomp &&
         cmake --build . -- -j2
       )
 

--- a/make/dmlc.mk
+++ b/make/dmlc.mk
@@ -20,10 +20,8 @@ else
 endif
 
 ifneq ($(USE_OPENMP), 0)
-ifneq ($(UNAME), Darwin)
 	DMLC_CFLAGS += -fopenmp
 	DMLC_LDFLAGS += -fopenmp
-endif
 endif
 
 ifeq (-android, $(findstring -android,$(MACHINE)))

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -11,10 +11,6 @@ if [[ ${TASK} == "lint" ]]; then
     exit 0
 fi
 
-if [[ ${TRAVIS_OS_NAME} == "osx" ]]; then
-    export NO_OPENMP=1
-fi
-
 # For all tests other than s390x_test, expect little endian
 export DMLC_UNIT_TEST_LITTLE_ENDIAN=1
 
@@ -26,6 +22,7 @@ if [[ ${TASK} == "unittest_gtest" ]]; then
         export CXX=g++-4.8
     else
         echo "USE_S3=0" >> config.mk
+        # OpenMP is only available on Mac OSX when CMake is used
         echo "USE_OPENMP=0" >> config.mk
     fi
     make -f scripts/packages.mk gtest
@@ -39,11 +36,7 @@ if [[ ${TASK} == "cmake_test" ]]; then
     # Build dmlc-core with CMake, including unit tests
     rm -rf build
     mkdir build && cd build
-    if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-        CC=gcc-7 CXX=g++-7 cmake .. -DGOOGLE_TEST=ON
-    else
-        cmake .. -DGOOGLE_TEST=ON
-    fi
+    cmake .. -DGOOGLE_TEST=ON
     make
     cd ..
     ./build/test/unittest/dmlc_unit_tests

--- a/scripts/travis/travis_script.sh
+++ b/scripts/travis/travis_script.sh
@@ -22,8 +22,9 @@ if [[ ${TASK} == "unittest_gtest" ]]; then
         export CXX=g++-4.8
     else
         echo "USE_S3=0" >> config.mk
-        # OpenMP is only available on Mac OSX when CMake is used
-        echo "USE_OPENMP=0" >> config.mk
+        echo "USE_OPENMP=1" >> config.mk
+        echo "export CXX=g++-8" >> config.mk
+        export CXX=g++-8
     fi
     make -f scripts/packages.mk gtest
     echo "GTEST_PATH="${CACHE_PREFIX} >> config.mk

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -61,4 +61,8 @@ else()
     ${GTEST_LIBRARIES} dmlc Threads::Threads)
 endif()
 
+if(USE_OPENMP)
+  target_link_libraries(dmlc_unit_tests OpenMP::OpenMP_CXX)
+endif()
+
 add_test(AllTestsInDMLCUnitTests ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dmlc_unit_tests)


### PR DESCRIPTION
Simplify logic for importing OpenMP into the CMake build by treating OpenMP as a target. This way, we no longer have to set compiler flags to enable OpenMP. See https://cliutils.gitlab.io/modern-cmake/chapters/packages/OpenMP.html for more information.

@dmlc/dmlc-core-committer @trivialfis Please help review. This will be especially useful for Mac OSX users. The old way requires them to use Homebrew GCC, which is a heavy dependency (*). The new way allows them to use Apple Clang (default system compiler) instead. 

(*) See discussion at https://github.com/Homebrew/homebrew-core/pull/43246, where Homebrew maintainers asked to remove GCC dependency from XGBoost.