### PR TITLE
Latest CMake not needed if GNU GCC is used on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,9 @@ endif()
 
 # OpenMP
 if(USE_OPENMP)
-  if(APPLE)
+  if(APPLE AND (NOT CMAKE_COMPILER_IS_GNUCC))
     # Require CMake 3.16+ for Mac to ensure that OpenMP can be located
+    # (Exception: it's okay if Homebrew GCC is used)
     cmake_minimum_required(VERSION 3.16)
   endif()
 


### PR DESCRIPTION
Follow-up to #586. CMake 3.16+ is needed only when the Mac's default compiler (Apple Clang) is used. Test if the user is using GNU GCC obtained via Homebrew. The goal is to be conservative when it comes to imposing the CMake version requirement.