### PR TITLE
[CI] Fix Travis OSX test caused by clashing Python version

### DIFF
--- a/scripts/travis/travis_osx_install.sh
+++ b/scripts/travis/travis_osx_install.sh
@@ -6,4 +6,8 @@ if [ ${TRAVIS_OS_NAME} != "osx" ]; then
     exit 0
 fi
 
+# Prevent clash between Python 2 and 3
+brew unlink python@2
+brew link --overwrite python
+
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
Fix error `python3: command not found` in the Travis CI, e.g. https://travis-ci.org/dmlc/dmlc-core/jobs/633124906