### PR TITLE
Upgrade Google Test to 1.10.0

### DIFF
--- a/cmake/gtest_cmake.in
+++ b/cmake/gtest_cmake.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1
+    GIT_TAG release-1.10.0
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""

--- a/scripts/packages.mk
+++ b/scripts/packages.mk
@@ -5,16 +5,16 @@
 
 # rules for gtest
 ${CACHE_PREFIX}/include/gtest:
-	rm -rf gtest release-1.8.1.zip
-	wget https://github.com/google/googletest/archive/release-1.8.1.zip
-	unzip release-1.8.1.zip
-	mv googletest-release-1.8.1 gtest
+	rm -rf gtest release-1.10.0.zip
+	wget https://github.com/google/googletest/archive/release-1.10.0.zip
+	unzip release-1.10.0.zip
+	mv googletest-release-1.10.0 gtest
 	cd gtest; $(CXX) $(CXXFLAGS) -Igoogletest -Igoogletest/include -pthread -c googletest/src/gtest-all.cc -o gtest-all.o; cd ..
 	$(AR) -rv libgtest.a gtest/gtest-all.o
 	mkdir -p ${CACHE_PREFIX}/include ${CACHE_PREFIX}/lib
 	cp -r gtest/googletest/include/gtest ${CACHE_PREFIX}/include
 	mv libgtest.a ${CACHE_PREFIX}/lib
-	rm -rf release-1.7.0.zip
+	rm -rf release-1.10.0.zip
 
 gtest: | ${CACHE_PREFIX}/include/gtest
 


### PR DESCRIPTION
The main change is the renaming of `...TestCase` to `...TestSuite`.

@hcho3 