### PR TITLE
Add CMake option to run Undefined Behavior Sanitizer (UBSan)

### DIFF
--- a/cmake/Modules/FindUBSan.cmake
+++ b/cmake/Modules/FindUBSan.cmake
@@ -1,0 +1,13 @@
+set(UBSan_LIB_NAME UBSan)
+
+find_library(UBSan_LIBRARY
+  NAMES libubsan.so libubsan.so.5 libubsan.so.4 libubsan.so.3 libubsan.so.2 libubsan.so.1 libubsan.so.0
+  PATHS ${SANITIZER_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib ${CMAKE_PREFIX_PATH}/lib)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(UBSan DEFAULT_MSG
+  UBSan_LIBRARY)
+
+mark_as_advanced(
+  UBSan_LIBRARY
+  UBSan_LIB_NAME)

--- a/cmake/Sanitizer.cmake
+++ b/cmake/Sanitizer.cmake
@@ -4,24 +4,29 @@
 #  enable_sanitizers("address;leak")
 
 # Add flags
-macro(enable_sanitizer santizer)
-  if(${santizer} MATCHES "address")
+macro(enable_sanitizer sanitizer)
+  if(${sanitizer} MATCHES "address")
     find_package(ASan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=address")
     link_libraries(${ASan_LIBRARY})
 
-  elseif(${santizer} MATCHES "thread")
+  elseif(${sanitizer} MATCHES "thread")
     find_package(TSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=thread")
     link_libraries(${TSan_LIBRARY})
 
-  elseif(${santizer} MATCHES "leak")
+  elseif(${sanitizer} MATCHES "leak")
     find_package(LSan REQUIRED)
     set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=leak")
     link_libraries(${LSan_LIBRARY})
 
+  elseif(${sanitizer} MATCHES "undefined")
+    find_package(UBSan REQUIRED)
+    set(SAN_COMPILE_FLAGS "${SAN_COMPILE_FLAGS} -fsanitize=undefined -fno-sanitize-recover=undefined")
+    link_libraries(${UBSan_LIBRARY})
+
   else()
-    message(FATAL_ERROR "Santizer ${santizer} not supported.")
+    message(FATAL_ERROR "Santizer ${sanitizer} not supported.")
   endif()
 endmacro()
 

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -148,6 +148,15 @@
 #define DMLC_ATTRIBUTE_UNUSED
 #endif
 
+/*! \brief helper macro to supress Undefined Behavior Sanitizer for a specific function */
+#if defined(__clang__)
+#define DMLC_SUPPRESS_UBSAN __attribute__((no_sanitize("undefined")))
+#elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)
+#define DMLC_SUPPRESS_UBSAN __attribute__((no_sanitize_undefined))
+#else
+#define DMLC_SUPPRESS_UBSAN
+#endif
+
 /*! \brief helper macro to generate string concat */
 #define DMLC_STR_CONCAT_(__x, __y) __x##__y
 #define DMLC_STR_CONCAT(__x, __y) DMLC_STR_CONCAT_(__x, __y)

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -642,6 +642,10 @@ class FieldEntryBase : public FieldAccessEntry {
       throw dmlc::ParamError(os.str());
     }
   }
+
+  // Don't check this function for Undefined Behavior (UB), as the function
+  // reads from a possibly uninitialized field
+  DMLC_SUPPRESS_UBSAN
   bool Same(void* head, std::string const& value) const override {
     DType old = this->Get(head);
     DType now;


### PR DESCRIPTION
This PR adds an CMake option to run UBSan (Undefined Behavior Sanitizer). It is motivated by https://news.ycombinator.com/item?id=22063849.

Example output:
```
/workspace/tests/cpp/common/../../../src/common/hist_util.h:40:11: runtime error: null pointer passed as argument 2, which is dec$
ared to never be null
    #0 0x5607d5de33c6 in xgboost::common::SimpleArray<unsigned int>::resize(unsigned long) /workspace/src/tree/./../common/hist_u$
il.h:40
    #1 0x5607d5dde9fd in xgboost::common::ColumnMatrix::Init(xgboost::common::GHistIndexMatrix const&, double) (/workspace/build/$
estxgboost+0x26b19fd)
    #2 0x5607d5dd89e5 in xgboost::common::DenseColumn_Test_Test::TestBody() /workspace/tests/cpp/common/test_column_matrix.cc:16
    #3 0x5607d6914a88 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void
(testing::Test::*)(), char const*) /workspace/build/googletest-src/googletest/src/gtest.cc:2443
    #4 0x5607d68ff70e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (te
sting::Test::*)(), char const*) /workspace/build/googletest-src/googletest/src/gtest.cc:2479
    #5 0x5607d687466f in testing::Test::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2517
    #6 0x5607d6877160 in testing::TestInfo::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2693
    #7 0x5607d6879355 in testing::TestCase::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:2811
    #8 0x5607d68ac3b6 in testing::internal::UnitTestImpl::RunAllTests() /workspace/build/googletest-src/googletest/src/gtest.cc:51
77
    #9 0x5607d6918e57 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(tes
ting::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspace/build/googletest-src/googletes
t/src/gtest.cc:2443
    #10 0x5607d6903013 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testi
ng::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /workspace/build/googletest-src/googletest/
src/gtest.cc:2479
    #11 0x5607d68a2309 in testing::UnitTest::Run() /workspace/build/googletest-src/googletest/src/gtest.cc:4786
    #12 0x5607d6178cd0 in RUN_ALL_TESTS() /workspace/build/googletest-src/googletest/include/gtest/gtest.h:2341
    #13 0x5607d61788f0 in main /workspace/tests/cpp/test_main.cc:14
    #14 0x7f9151aa3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #15 0x5607d5da1869 in _start (/workspace/build/testxgboost+0x2674869)
```