### PR TITLE
support unified host file for ssh and mpi

### DIFF
--- a/tracker/dmlc_tracker/ssh.py
+++ b/tracker/dmlc_tracker/ssh.py
@@ -45,6 +45,13 @@ def submit(args):
         if len(h.strip()) > 0:
             # parse addresses of the form ip:port
             h = h.strip()
+
+            # parse mpi host file form ip slots=??
+            # this is to create an unified api for mpi and ssh
+            i = h.find("slots=")
+            if i != -1:
+                h = h[:i].strip()
+
             i = h.find(":")
             p = "22"
             if i != -1:


### PR DESCRIPTION
This change allows users to use one host file when switching between different launchers like mpi and ssh. 

In the case of mpi, the host file spec looks like
<ip address> slots=<n>

In the case of ssh, the host file spec looks like
<ip address>

If users supply the host file for mpi to ssh it will still work by ignoring the "slots=" suffix.

@eric-haibin-lin please review.