### PR TITLE
Disable GCC v6+ -Wmaybe-uninitialized in optional.h

### DIFF
--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -46,15 +46,25 @@ class optional {
   optional() : is_none(true) {}
   /*! \brief construct an optional object with value */
   explicit optional(const T& value) {
+#pragma GCC diagnostic push
+#if __GNUC__ >= 6
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     is_none = false;
     new (&val) T(value);
+#pragma GCC diagnostic pop
   }
   /*! \brief construct an optional object with another optional object */
   optional(const optional<T>& other) {
+#pragma GCC diagnostic push
+#if __GNUC__ >= 6
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     is_none = other.is_none;
     if (!is_none) {
       new (&val) T(other.value());
     }
+#pragma GCC diagnostic pop
   }
   /*! \brief deconstructor */
   ~optional() {


### PR DESCRIPTION
Triggered by

https://github.com/apache/incubator-mxnet/blob/c2e9a885683774f229eebdcf2699f51bc3afb3d9/src/operator/tensor/matrix_op-inl.h#L1470-L1505

Warning

```
In file included from ../include/dmlc/./parameter.h:29,
                 from ../include/dmlc/registry.h:14,
                 from ../include/mxnet/operator_util.h:37,
                 from ../src/operator/tensor/./matrix_op-inl.h:28,
                 from ../src/operator/tensor/matrix_op.cc:26:
../include/dmlc/././optional.h: In function ‘void mxnet::op::SliceLikeInferRanges(const mxnet::TShape&, const mxnet::TShape&, const mxnet::Tuple<int>&, mxnet::Tuple<dmlc::optional<int> >*, mxnet::Tuple<dmlc::optional<int> >*, mxnet::Tuple<dmlc::optional<int> >*)’:
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +20)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       new (&val) T(other.value());
       ^~~
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +28)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +36)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +20)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       new (&val) T(other.value());
       ^~~
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +28)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +36)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +20)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       new (&val) T(other.value());
       ^~~
../include/dmlc/././optional.h:56:7: warning: ‘*((void*)&<anonymous> +28)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```