### PR TITLE
[Breaking] Don't push zero when value is missing in CSV parser.

### DIFF
--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -109,7 +109,6 @@ ParseBlock(const char *begin,
       } else {
         LOG(FATAL) << "Only float32, int32, and int64 are supported for the time being";
       }
-      p = (endptr >= lend) ? lend : endptr;
 
       if (column_index == param_.label_column) {
         label = v;
@@ -117,9 +116,14 @@ ParseBlock(const char *begin,
                  && column_index == param_.weight_column) {
         weight = v;
       } else {
-        out->value.push_back(v);
-        out->index.push_back(idx++);
+        if (std::distance(p, static_cast<char const*>(endptr)) != 0) {
+          out->value.push_back(v);
+          out->index.push_back(idx++);
+        } else {
+          idx++;
+        }
       }
+      p = (endptr >= lend) ? lend : endptr;
       ++column_index;
       while (*p != param_.delimiter[0] && p != lend) ++p;
       if (p == lend && idx == 0) {

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -105,6 +105,27 @@ TEST(CSVParser, test_standard_case) {
   }
 }
 
+TEST(CSVParser, missing_values) {
+  using namespace parser_test;
+  InputSplit *source = nullptr;
+  const std::map<std::string, std::string> args;
+  std::unique_ptr<CSVParserTest<unsigned>> parser(
+      new CSVParserTest<unsigned>(source, args, 1));
+  std::unique_ptr<RowBlockContainer<unsigned>> rctr { new RowBlockContainer<unsigned>() };
+  std::string data = "0,,,3\n4,5,6,7\n8,9,10,11\n";
+  char *out_data = const_cast<char *>(data.c_str());
+  parser->CallParseBlock(out_data, out_data + data.size(), rctr.get());
+  CHECK_EQ(rctr->value.size(), 10);
+  CHECK(rctr->value[0] == 0);
+  CHECK(rctr->index[0] == 0);
+  CHECK_EQ(rctr->value[1], 3);
+  CHECK(rctr->index[1] == 3);
+
+  for (size_t i = 2; i < rctr->value.size(); ++i) {
+    CHECK_EQ(rctr->value[i], i + 2);
+  }
+}
+
 TEST(CSVParser, test_int32_parse) {
   using namespace parser_test;
   InputSplit *source = nullptr;

--- a/test/unittest/unittest_parser.cc
+++ b/test/unittest/unittest_parser.cc
@@ -75,18 +75,19 @@ TEST(CSVParser, test_ignore_bom) {
   std::unique_ptr<CSVParserTest<unsigned>> parser(
       new CSVParserTest<unsigned>(source, args, 1));
   std::string data = "\xEF\xBB\xBF\x31\n\xEF\xBB\x32\n";
-  char *out_data = (char *)data.c_str();
+  char *out_data = const_cast<char *>(data.c_str());
   std::unique_ptr<RowBlockContainer<unsigned> > rctr {new RowBlockContainer<unsigned>()};
   parser->CallParseBlock(out_data, out_data + data.size(), rctr.get());
-  CHECK(rctr->value[0] == 1);
-  CHECK(rctr->value[1] == 0);
+  CHECK(rctr->value.size() == 1);
+  CHECK(rctr->value.at(0) == 1);
+
   data = "\xEF\xBB\xBF\x31\n\xEF\xBB\xBF\x32\n";
-  out_data = (char *)data.c_str();
+  out_data = const_cast<char *>(data.c_str());
   rctr.reset(new RowBlockContainer<unsigned>());
   parser->CallParseBlock(out_data, out_data + data.size(), rctr.get());
-
-  CHECK(rctr->value[0] == 1);
-  CHECK(rctr->value[1] == 2);
+  CHECK(rctr->value.size() == 2);
+  CHECK(rctr->value.at(0) == 1);
+  CHECK(rctr->value.at(1) == 2);
 }
 
 TEST(CSVParser, test_standard_case) {


### PR DESCRIPTION
Currently when the value is missing, CSV parser pushes a default value into row
block, which is zero for all data types.  This defeats the purpose of CSR like
row block and generates false information about the data.  Hence I made a
breaking change instead of an addition parameter.

Fix: dmlc/xgboost#5456 .