### PR TITLE
Define `omp_in_parallel` stub.

### DIFF
--- a/include/dmlc/omp.h
+++ b/include/dmlc/omp.h
@@ -31,6 +31,7 @@ inline int omp_get_num_threads() __GOMP_NOTHROW { return 1; }
 inline int omp_get_max_threads() __GOMP_NOTHROW { return 1; }
 inline int omp_get_num_procs() __GOMP_NOTHROW { return 1; }
 inline void omp_set_num_threads(int nthread) __GOMP_NOTHROW {}
+inline int omp_in_parallel() __GOMP_NOTHROW { return 0; }
 #ifdef __cplusplus
 }
 #endif  // __cplusplus


### PR DESCRIPTION
Related issue: https://github.com/dmlc/xgboost/issues/5518