### PR TITLE
[Breaking] Remove optional `changed` parameter.

### DIFF
--- a/test/unittest/unittest_param.cc
+++ b/test/unittest/unittest_param.cc
@@ -162,28 +162,21 @@ TEST(Parameter, parsing_float) {
 
 TEST(Parameter, Update) {
   LearningParam param;
-  bool changed = false;
   using Args = std::vector<std::pair<std::string, std::string> >;
   auto unknown =
       param.UpdateAllowUnknown(Args{{"float_param", "0.02"},
-                                    {"foo", "bar"}}, &changed);
+                                    {"foo", "bar"}});
   ASSERT_EQ(unknown.size(), 1);
   ASSERT_EQ(unknown[0].first, "foo");
   ASSERT_EQ(unknown[0].second, "bar");
   ASSERT_NEAR(param.float_param, 0.02f, 1e-6);
-  ASSERT_TRUE(changed);
 
   param.float_param = 0.02;
   param.UpdateAllowUnknown(Args{{"float_param", "0.02"},
-                                {"foo", "bar"}}, &changed);
-  ASSERT_FALSE(changed);
-
-  param.UpdateAllowUnknown(Args{{"foo", "bar"}}, &changed);
-  ASSERT_FALSE(changed);
-
+                                {"foo", "bar"}});
+  param.UpdateAllowUnknown(Args{{"foo", "bar"}});
   param.UpdateAllowUnknown(Args{{"double_param", "0.13"},
-                                {"foo", "bar"}}, &changed);
-  ASSERT_TRUE(changed);
+                                {"foo", "bar"}});
   ASSERT_NEAR(param.float_param, 0.02f, 1e-6);  // stays the same
   ASSERT_NEAR(param.double_param, 0.13, 1e-6);
 }

--- a/test/unittest/unittest_thread_group.cc
+++ b/test/unittest/unittest_thread_group.cc
@@ -191,8 +191,7 @@ TEST(ThreadGroup, TimerThread) {
       if ((count + 1) % 5 == 0) {
         // output slows it down a bit, so print fewer times
         std::cout << "[" << (count + 1) << "] TIME: "
-                  << GetDurationInMilliseconds(start_time)
-                  << std::endl << std::flush;
+                  << GetDurationInMilliseconds(start_time) << "\n";
       }
       ++count;
       return 0;  // return 0 means continue
@@ -224,8 +223,7 @@ TEST(ThreadGroup, TimerThreadSimple) {
                       if ((count + 1) % 5 == 0) {
                         // output slows it down a bit, so print fewer times
                         std::cout << "[" << (count + 1) << "] TIME: "
-                                  << GetDurationInMilliseconds(start_time)
-                                  << std::endl << std::flush;
+                                  << GetDurationInMilliseconds(start_time) << "\n";
                       }
                       ++count;
                       return 0;  // return 0 means continue


### PR DESCRIPTION
I made the optional parameter for users to detect whether some parameters have been changed.  So far it doesn't seem to be useful in practice, users can just save the old value and compare it themselves.  Supporting this parameter requires a `Same` function to compare raw memory, which could be uninitialized.  This results in many complains and false alarms from analyzers like clang-tidy, ubsan, valgrind.