### PR TITLE
[Logging] Reducing stack usage by moving `dmlc::LogMessageFatal` to the heap

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -205,7 +205,8 @@ class LogCheckError {
 
 #define CHECK_BINARY_OP(name, op, x, y)                               \
   if (dmlc::LogCheckError _check_err = dmlc::LogCheck##name(x, y))    \
-    dmlc::LogMessageFatal(__FILE__, __LINE__).stream()                \
+    std::unique_ptr<dmlc::LogMessageFatal>(                           \
+      new dmlc::LogMessageFatal(__FILE__, __LINE__))->stream()        \
       << "Check failed: " << #x " " #op " " #y << *(_check_err.str) << ": "
 
 #pragma GCC diagnostic push
@@ -219,9 +220,10 @@ DEFINE_CHECK_FUNC(_NE, !=)
 #pragma GCC diagnostic pop
 
 // Always-on checking
-#define CHECK(x)                                           \
-  if (!(x))                                                \
-    dmlc::LogMessageFatal(__FILE__, __LINE__).stream()     \
+#define CHECK(x)                                                \
+  if (!(x))                                                     \
+    std::unique_ptr<dmlc::LogMessageFatal>(                     \
+      new dmlc::LogMessageFatal(__FILE__, __LINE__))->stream()  \
       << "Check failed: " #x << ": "
 #define CHECK_LT(x, y) CHECK_BINARY_OP(_LT, <, x, y)
 #define CHECK_GT(x, y) CHECK_BINARY_OP(_GT, >, x, y)


### PR DESCRIPTION
When working on `tvm::runtime::Array`, we found that `CHECK` causes significant regression in stack utilization. This is not acceptable especially in compilers written in recursive visitor pattern, which crashes on comparably deep neural networks.

As diving deeper into this case, we figured out that `dmlc::LogMessageFatal` is the cause - it is super sophisticated and throws inside the destructor.

So we would love to patch dmlc-core, move `dmlc::LogMessageFatal` from stack to heap. A simple trick is to wrap it with `std::unique_ptr` - it is doable because dmlc-core has been updated to C++ 11.

Besides patching dmlc-core, we can change the implementation of `tvm::runtime::Array` as well as follows:
0) no change (using CHECK)
1) throw dmlc::Error instead of using CHECK
2) throw std::runtime_error instead of using CHECK 
3) remove and disable the CHECK

Below are the benchmarks we did. We use `g++ -fstack-usage` to dump the stack usage information for the target function.

Settings:
* Compiler: g++ 5.4
* OS: Ubuntu 18.04
* Stack size: ulimit -s 8192
* Target function: `virtual tvm::relay::Expr tvm::relay::CommonSubexprEliminator::VisitExpr_(const tvm::relay::CallNode*)`, which originally crashed [this PR](https://github.com/apache/incubator-tvm/pull/5585) on a very deep network

Results:

|                          | Patch dmlc-core | No patch dmlc-core |
|--------------------------|-----------------|--------------------|
| CHECK                    | 560             | 4656               |
| throw dmlc::Error        | 736             | 1264               |
| throw std::runtime_error | 480             | 1008               |
| No checks (no-op)                | 480             | 1008               |

Side notes: It is unclear right now why throwing `dmlc::Error` takes more stack space than `std::runtime_error`, although they intent to be identical.

See also: https://github.com/apache/incubator-tvm/pull/5585#issuecomment-631147088
