### PR TITLE
[CI] Upgrade to GCC 5, use C++11 by default

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Dependencies
         run: |
           if [[ $(uname) != "Darwin" ]]; then
-            sudo apt install doxygen libcurl4-openssl-dev gcc-4.8 g++-4.8
+            sudo apt install doxygen libcurl4-openssl-dev gcc-5 g++-5
           else
             brew install libomp doxygen
           fi

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -32,7 +32,7 @@ jobs:
           TASK=lint ./scripts/test_script.sh
       - name: googletest
         run: |
-          if [[ $(uname) != "Darwin" ]]; then
+          if [[ "${{ matrix.task }}" == "s390x_test" ]]; then
             docker run --rm --privileged multiarch/qemu-user-static:register --reset
           fi
           TASK=${{ matrix.task }} ./scripts/test_script.sh

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,7 @@ NOLINT_FILES = --exclude_path include/dmlc/concurrentqueue.h include/dmlc/blocki
 # this is the common build script for dmlc lib
 export LDFLAGS= -pthread -lm
 export CFLAGS = -O3 -Wall -Wno-unknown-pragmas -Iinclude
-ifeq ($(USE_GNU11), 1)
-	CFLAGS += -std=gnu++11
-else
-	CFLAGS += -std=c++0x
-endif
+CFLAGS+=-std=c++11
 LDFLAGS+= $(DMLC_LDFLAGS) $(ADD_LDFLAGS)
 CFLAGS+= $(DMLC_CFLAGS) $(ADD_CFLAGS)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Contributing
 
 Contributing to dmlc-core is welcomed! dmlc-core follows google's C style guide. If you are interested in contributing, take a look at [feature wishlist](https://github.com/dmlc/dmlc-core/labels/feature%20wishlist) and open a new issue if you like to add something.
 
-* Use of c++11 is allowed, given that the code is macro guarded with ```DMLC_USE_CXX11```
+* DMLC-Core uses C++11 standard. Ensure that your C++ compiler supports C++11.
 * Try to introduce minimum dependency when possible
 
 ### CheckList before submit code

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -116,12 +116,12 @@
 #define DMLC_USE_FOPEN64 1
 #endif
 
-/// check if g++ is before 4.6
+/// check if g++ is before 5.0
 #if DMLC_USE_CXX11 && defined(__GNUC__) && !defined(__clang_version__)
-#if __GNUC__ == 4 && __GNUC_MINOR__ < 6
-#pragma message("Will need g++-4.6 or higher to compile all"           \
+#if __GNUC__ < 5
+#pragma message("Will need g++-5.0 or higher to compile all"           \
                 "the features in dmlc-core, "                           \
-                "compile without c++0x, some features may be disabled")
+                "compile without c++11, some features may be disabled")
 #undef DMLC_USE_CXX11
 #define DMLC_USE_CXX11 0
 #endif

--- a/make/config.mk
+++ b/make/config.mk
@@ -51,6 +51,3 @@ GTEST_PATH=
 
 # path to third-party dependences such as glog
 DEPS_PATH=
-
-# whether to use gnu++11 (Cygwin need this turned on to avoid compile error)
-USE_GNU11=0

--- a/scripts/test_script.sh
+++ b/scripts/test_script.sh
@@ -23,8 +23,8 @@ if [[ ${TASK} == "unittest_gtest" ]]; then
     cp make/config.mk .
     if [[ $(uname) != "Darwin" ]]; then
         echo "USE_S3=1" >> config.mk
-        echo "export CXX = g++-4.8" >> config.mk
-        export CXX=g++-4.8
+        echo "export CXX = g++-5" >> config.mk
+        export CXX=g++-5
     else
         echo "USE_S3=0" >> config.mk
         echo "USE_OPENMP=1" >> config.mk


### PR DESCRIPTION
We already require C++11 for the project to compile:
https://github.com/dmlc/dmlc-core/blob/6677574aa7fd8620669482e738953d5abb14d527/CMakeLists.txt#L36

cc @trivialfis 