### PR TITLE
[logging] simplify and optimize CHECK_** macro

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -242,6 +242,14 @@ typedef unsigned __int64 uint64_t;
 #define DMLC_NO_INLINE __attribute__((noinline))
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#define DMLC_ALWAYS_INLINE inline __attribute__((__always_inline__))
+#elif defined(_MSC_VER)
+#define DMLC_ALWAYS_INLINE __forceinline
+#else
+#define DMLC_ALWAYS_INLINE inline
+#endif
+
 #if DMLC_USE_CXX11
 #define DMLC_THROW_EXCEPTION noexcept(false)
 #define DMLC_NO_EXCEPTION  noexcept(true)

--- a/test/unittest/unittest_logging.cc
+++ b/test/unittest/unittest_logging.cc
@@ -18,6 +18,14 @@ TEST(Logging, basics) {
   EXPECT_THROW(CHECK_NE(x, y), dmlc::Error);
 }
 
+TEST(Logging, signed_compare) {
+  int32_t x = 1;
+  uint32_t y = 2;
+  CHECK_GT(y, x);
+
+  EXPECT_THROW(CHECK_EQ(x, y), dmlc::Error);
+}
+
 TEST(Logging, throw_fatal) {
   EXPECT_THROW({
     LOG(FATAL) << "message";


### PR DESCRIPTION
https://github.com/dmlc/xgboost/blob/91c646392db01714a4f69c33170fb0857b95664d/src/data/data.cc#L653-L658

This CHECK_GE is expensive and makes xgboost data loading ~15% slower. Call to LogCheck_GE was not inlined by GCC, but forcing inlining it would be also problematic, as the function was big. This change makes is more efficient and simplifies the code at the same time. Please let me know if I'm missing some cases affected by this simplification (if any).

Brief summary:
1) avoid expensive function call. Keep LogCheck_ function itself, but limit its scope to comparison only, this one will be inlined by sensible compiler. It's still easier to keep the function rather than just do comparison in the macro itself, because of -Wsign-compare pragmas;
2) move full message construction to the macro definition;
3) get rid of LogCheckError class entirely;
4) remove the preprocessor branch for _LIBCPP_SGX_NO_IOSTREAMS, as
nothing was going to be printed anywhere anyway in that case, it would all go to DummyOStream;
5) add a test case for signed/unsigned comparison.

Data loading time, higgs dataset, 10 attempts. Both were based on most recent dmlc-core.

| base      | new |
| ------------- | ------------- |
|9.55223 | 7.65502|
|9.34264 | 7.8101|
|9.15207 | 7.7555|
|8.99823 | 8.23572|
|9.20671 | 7.85532|
|9.16312 | 8.95983|
|9.27071 | 8.81042|
|9.27828 | 8.26593|
|9.39034 | 7.90145|
|9.61453 | 8.06095|

Also see https://github.com/dmlc/xgboost/issues/5722 