### PR TITLE
[logging] fix CHECK macro.

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -164,16 +164,22 @@ inline bool DebugLoggingEnabled() {
 
 #ifndef DMLC_GLOG_DEFINED
 
+template <typename X, typename Y>
+std::string* LogCheckFormat(const X& x, const Y& y) {
+  std::ostringstream os;
+  os << " (" << x << " vs. " << y << ") "; /* CHECK_XX(x, y) requires x and y can be serialized to string. Use CHECK(x OP y) otherwise. NOLINT(*) */
+  return new std::string(os.str());
+}
+
 // This function allows us to ignore sign comparison in the right scope.
-// Once dmlc requires c++11, #pragma can be changed to _Pramga, and directives
-// can be moved to CHECK_BINARY_OP definition itself
-#define DEFINE_CHECK_FUNC(name, op)                                \
-  template <typename X, typename Y>                                \
-  DMLC_ALWAYS_INLINE bool LogCheck##name(const X& x, const Y& y) { \
-    return (x op y);                                               \
-  }                                                                \
-  DMLC_ALWAYS_INLINE bool LogCheck##name(int x, int y) {           \
-    return LogCheck##name<int, int>(x, y);                         \
+#define DEFINE_CHECK_FUNC(name, op)                                        \
+  template <typename X, typename Y>                                        \
+  DMLC_ALWAYS_INLINE std::string* LogCheck##name(const X& x, const Y& y) { \
+    if (x op y) return nullptr;                                            \
+    return LogCheckFormat(x, y);                                           \
+  }                                                                        \
+  DMLC_ALWAYS_INLINE std::string* LogCheck##name(int x, int y) {           \
+    return LogCheck##name<int, int>(x, y);                                 \
   }
 
 #pragma GCC diagnostic push
@@ -187,9 +193,9 @@ DEFINE_CHECK_FUNC(_NE, !=)
 #pragma GCC diagnostic pop
 
 #define CHECK_BINARY_OP(name, op, x, y)                  \
-  if (!(dmlc::LogCheck##name(x, y)))                     \
+  if (std::string* err = dmlc::LogCheck##name(x, y))     \
       dmlc::LogMessageFatal(__FILE__, __LINE__).stream() \
-        << "Check failed: " << #x " " #op " " #y << " (" << x << " vs. " << y << ") " << ": " /* CHECK_XX(x, y) requires x and y can be serialized to string. Use CHECK(x OP y) otherwise. NOLINT(*) */
+        << "Check failed: " << #x " " #op " " #y << *err << ": "
 
 // Always-on checking
 #define CHECK(x)                                           \

--- a/test/unittest/unittest_logging.cc
+++ b/test/unittest/unittest_logging.cc
@@ -26,6 +26,31 @@ TEST(Logging, signed_compare) {
   EXPECT_THROW(CHECK_EQ(x, y), dmlc::Error);
 }
 
+TEST(Logging, expression_in_check) {
+  uint32_t y = 64;
+  CHECK_EQ(y & (y - 1), 0);
+}
+
+TEST(Logging, extra_message) {
+  uint32_t y = 64;
+  CHECK_EQ(y & (y - 1), 0) << y << " has to be power of 2";
+}
+
+TEST(Logging, single_evaluation) {
+  uint32_t y = 1;
+  try {
+    CHECK_EQ(y++, 2);
+    FAIL() << "y = 1; CHECK_EQ(y++, 2) must throw an exception";
+  } catch (std::runtime_error& exception) {
+    // if everything is correct, y++ is evaluated only once, and '1' would be
+    // mentioned in error message. This relies on specific format of error message,
+    // if it changes, this unit test will have to be changed as well.
+    EXPECT_NE(std::string(exception.what()).find("(1 vs"), std::string::npos);
+  } catch (...) {
+    FAIL() << "unexpected exception in CHECK_EQ(y++, 2)"; 
+  }
+}
+
 TEST(Logging, throw_fatal) {
   EXPECT_THROW({
     LOG(FATAL) << "message";

--- a/test/unittest/unittest_thread_group.cc
+++ b/test/unittest/unittest_thread_group.cc
@@ -202,8 +202,8 @@ TEST(ThreadGroup, TimerThread) {
   thread_group->request_shutdown_all(true);
   // Wait for all of the queue threads to exit
   thread_group->join_all();
-  GTEST_ASSERT_GE(count, MIN_COUNT_WHILE_SLEEPING);  // Should have at least done three
-  GTEST_ASSERT_LE(count, MAX_COUNT_WHILE_SLEEPING); // Should not have had time to do 20 of them
+  GTEST_ASSERT_GE(count, MIN_COUNT_WHILE_SLEEPING);  // Should have at least done 10
+  GTEST_ASSERT_LE(count, MAX_COUNT_WHILE_SLEEPING); // Should not have had time to do 150 of them
 }
 
 /*!
@@ -235,6 +235,6 @@ TEST(ThreadGroup, TimerThreadSimple) {
   thread_group->request_shutdown_all();
   // Wait for all of the queue threads to exit
   thread_group->join_all();
-  GTEST_ASSERT_GE(count, MIN_COUNT_WHILE_SLEEPING);  // Should have at least done three
-  GTEST_ASSERT_LE(count, MAX_COUNT_WHILE_SLEEPING); // Should not have had time to do 20 of them
+  GTEST_ASSERT_GE(count, MIN_COUNT_WHILE_SLEEPING);  // Should have at least done 10
+  GTEST_ASSERT_LE(count, MAX_COUNT_WHILE_SLEEPING); // Should not have had time to do 150 of them
 }


### PR DESCRIPTION
In https://github.com/dmlc/dmlc-core/pull/619 I broke 2 things about CHECK_** (sorry!):
1) missing parentheses, so some expressions would be evaluated incorrectly and might not even compile. (thanks for catching this in https://github.com/dmlc/dmlc-core/issues/620)
2) if expression is provided, it needs to be evaluated just once, otherwise code like CHECK_EQ(x++, 10) will print out wrong message in case of a failure.

To fix that and keep perf win, formatting was reintroduced back to LogCheck##name. It's been moved to separate function though, so, compiler will inline function doing the check, but 'outline' the expensive formatting one, thus, doing call to larger, expensive function only in case of a failure. 

I double-checked that perf win still holds:

Current version:
Loading data: 7.47028 sec
Loading data: 7.72023 sec
Loading data: 7.99132 sec
Loading data: 7.93434 sec
Loading data: 7.06726 sec
Loading data: 7.60153 sec
Loading data: 8.46663 sec
Loading data: 8.31967 sec
Loading data: 7.37396 sec
Loading data: 7.41063 sec

Old, before PR 619:
Loading data: 9.34473 sec
Loading data: 9.47449 sec
Loading data: 9.56089 sec
Loading data: 9.57217 sec
Loading data: 9.22075 sec
Loading data: 8.84541 sec
Loading data: 9.21536 sec
Loading data: 9.67341 sec
Loading data: 8.94046 sec
Loading data: 9.28459 sec

