### PR TITLE
Revert "[CI] Reorder #include to comply with cpplint 1.5.0 (#622)"

### DIFF
--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -7,12 +7,12 @@
 #ifndef DMLC_FILESYSTEM_H_
 #define DMLC_FILESYSTEM_H_
 
+#include <dmlc/logging.h>
+#include <dmlc/io.h>
 #include <algorithm>
 #include <string>
 #include <vector>
 #include <random>
-#include <dmlc/logging.h>
-#include <dmlc/io.h>
 
 /* platform specific headers */
 #ifdef _WIN32

--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -7,17 +7,17 @@
  */
 #ifndef DMLC_LOGGING_H_
 #define DMLC_LOGGING_H_
-#include <sstream>
+#include <cstdio>
+#include <cstdlib>
 #include <string>
 #include <vector>
 #include <stdexcept>
 #include <memory>
-#include <cstdio>
-#include <cstdlib>
 #include "./base.h"
 
 #if DMLC_LOG_STACK_TRACE
 #include <cxxabi.h>
+#include <sstream>
 #include DMLC_EXECINFO_H
 #endif
 

--- a/include/dmlc/lua.h
+++ b/include/dmlc/lua.h
@@ -29,6 +29,12 @@
 #ifndef DMLC_LUA_H_
 #define DMLC_LUA_H_
 
+extern "C" {
+#include <lua.h>
+#include <luaT.h>
+#include <lualib.h>
+}
+
 #include <string>
 #include <stdexcept>
 #include <tuple>
@@ -39,12 +45,6 @@
 #include <algorithm>
 #include <unordered_map>
 #include <type_traits>
-
-extern "C" {
-#include <lua.h>
-#include <luaT.h>
-#include <lualib.h>
-}
 
 #include "./base.h"
 #include "./logging.h"

--- a/include/dmlc/thread_group.h
+++ b/include/dmlc/thread_group.h
@@ -6,6 +6,9 @@
 #ifndef DMLC_THREAD_GROUP_H_
 #define DMLC_THREAD_GROUP_H_
 
+#include <dmlc/concurrentqueue.h>
+#include <dmlc/blockingconcurrentqueue.h>
+#include <dmlc/logging.h>
 #include <string>
 #include <mutex>
 #include <utility>
@@ -14,9 +17,6 @@
 #include <thread>
 #include <unordered_set>
 #include <unordered_map>
-#include <dmlc/concurrentqueue.h>
-#include <dmlc/blockingconcurrentqueue.h>
-#include <dmlc/logging.h>
 #if defined(DMLC_USE_CXX14) || __cplusplus > 201103L  /* C++14 */
 #include <shared_mutex>
 #endif

--- a/src/data.cc
+++ b/src/data.cc
@@ -1,11 +1,11 @@
 // Copyright by Contributors
-#include <string>
-#include <cstring>
 #include <dmlc/base.h>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
 #include <dmlc/data.h>
 #include <dmlc/registry.h>
+#include <cstring>
+#include <string>
 #include "io/uri_spec.h"
 #include "data/parser.h"
 #include "data/basic_row_iter.h"

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -7,14 +7,14 @@
 #ifndef DMLC_DATA_CSV_PARSER_H_
 #define DMLC_DATA_CSV_PARSER_H_
 
-#include <map>
-#include <string>
-#include <limits>
-#include <cmath>
-#include <cstring>
 #include <dmlc/data.h>
 #include <dmlc/strtonum.h>
 #include <dmlc/parameter.h>
+#include <cmath>
+#include <cstring>
+#include <map>
+#include <string>
+#include <limits>
 #include "./row_block.h"
 #include "./text_parser.h"
 

--- a/src/data/disk_row_iter.h
+++ b/src/data/disk_row_iter.h
@@ -8,13 +8,13 @@
 #ifndef DMLC_DATA_DISK_ROW_ITER_H_
 #define DMLC_DATA_DISK_ROW_ITER_H_
 
-#include <algorithm>
-#include <string>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
 #include <dmlc/data.h>
 #include <dmlc/timer.h>
 #include <dmlc/threadediter.h>
+#include <algorithm>
+#include <string>
 #include "./row_block.h"
 #include "./libsvm_parser.h"
 

--- a/src/data/libfm_parser.h
+++ b/src/data/libfm_parser.h
@@ -7,14 +7,14 @@
 #ifndef DMLC_DATA_LIBFM_PARSER_H_
 #define DMLC_DATA_LIBFM_PARSER_H_
 
+#include <dmlc/data.h>
+#include <dmlc/strtonum.h>
+#include <dmlc/parameter.h>
 #include <map>
 #include <string>
 #include <limits>
 #include <algorithm>
 #include <cstring>
-#include <dmlc/data.h>
-#include <dmlc/strtonum.h>
-#include <dmlc/parameter.h>
 #include "./row_block.h"
 #include "./text_parser.h"
 

--- a/src/data/libsvm_parser.h
+++ b/src/data/libsvm_parser.h
@@ -7,14 +7,14 @@
 #ifndef DMLC_DATA_LIBSVM_PARSER_H_
 #define DMLC_DATA_LIBSVM_PARSER_H_
 
+#include <dmlc/data.h>
+#include <dmlc/strtonum.h>
+#include <dmlc/parameter.h>
 #include <map>
 #include <string>
 #include <limits>
 #include <algorithm>
 #include <cstring>
-#include <dmlc/data.h>
-#include <dmlc/strtonum.h>
-#include <dmlc/parameter.h>
 #include "./row_block.h"
 #include "./text_parser.h"
 

--- a/src/data/parser.h
+++ b/src/data/parser.h
@@ -7,10 +7,10 @@
 #ifndef DMLC_DATA_PARSER_H_
 #define DMLC_DATA_PARSER_H_
 
-#include <vector>
 #include <dmlc/base.h>
 #include <dmlc/logging.h>
 #include <dmlc/threadediter.h>
+#include <vector>
 #include "./row_block.h"
 
 namespace dmlc {

--- a/src/data/row_block.h
+++ b/src/data/row_block.h
@@ -8,13 +8,13 @@
 #ifndef DMLC_DATA_ROW_BLOCK_H_
 #define DMLC_DATA_ROW_BLOCK_H_
 
-#include <vector>
-#include <limits>
-#include <algorithm>
-#include <cstring>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
 #include <dmlc/data.h>
+#include <cstring>
+#include <vector>
+#include <limits>
+#include <algorithm>
 
 namespace dmlc {
 namespace data {

--- a/src/data/text_parser.h
+++ b/src/data/text_parser.h
@@ -7,14 +7,14 @@
 #ifndef DMLC_DATA_TEXT_PARSER_H_
 #define DMLC_DATA_TEXT_PARSER_H_
 
-#include <algorithm>
+#include <dmlc/data.h>
+#include <dmlc/omp.h>
+#include <dmlc/common.h>
 #include <thread>
 #include <mutex>
 #include <vector>
 #include <cstring>
-#include <dmlc/data.h>
-#include <dmlc/omp.h>
-#include <dmlc/common.h>
+#include <algorithm>
 #include "./row_block.h"
 #include "./parser.h"
 

--- a/src/io.cc
+++ b/src/io.cc
@@ -1,9 +1,9 @@
 // Copyright by Contributors
 
-#include <cstring>
 #include <dmlc/base.h>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
+#include <cstring>
 #include "io/uri_spec.h"
 #include "io/line_split.h"
 #include "io/recordio_split.h"

--- a/src/io/azure_filesys.h
+++ b/src/io/azure_filesys.h
@@ -7,9 +7,9 @@
 #ifndef DMLC_IO_AZURE_FILESYS_H_
 #define DMLC_IO_AZURE_FILESYS_H_
 
+#include <dmlc/filesystem.h>
 #include <vector>
 #include <string>
-#include <dmlc/filesystem.h>
 
 namespace dmlc {
 namespace io {

--- a/src/io/cached_input_split.h
+++ b/src/io/cached_input_split.h
@@ -9,13 +9,13 @@
 #ifndef DMLC_IO_CACHED_INPUT_SPLIT_H_
 #define DMLC_IO_CACHED_INPUT_SPLIT_H_
 
-#include <string>
-#include <algorithm>
 #include <dmlc/base.h>
 // this code depends on c++11
 
 #if DMLC_ENABLE_STD_THREAD
 #include <dmlc/threadediter.h>
+#include <string>
+#include <algorithm>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/filesys.cc
+++ b/src/io/filesys.cc
@@ -1,7 +1,7 @@
 // Copyright by Contributors
 
-#include <queue>
 #include <dmlc/filesystem.h>
+#include <queue>
 
 namespace dmlc {
 namespace io {

--- a/src/io/hdfs_filesys.cc
+++ b/src/io/hdfs_filesys.cc
@@ -1,7 +1,7 @@
 // Copyright by Contributors
+#include <dmlc/logging.h>
 #include <algorithm>
 #include <limits>
-#include <dmlc/logging.h>
 #include "./hdfs_filesys.h"
 
 namespace dmlc {

--- a/src/io/hdfs_filesys.h
+++ b/src/io/hdfs_filesys.h
@@ -6,13 +6,13 @@
  */
 #ifndef DMLC_IO_HDFS_FILESYS_H_
 #define DMLC_IO_HDFS_FILESYS_H_
-#include <vector>
-#include <string>
-
 extern "C" {
 #include <hdfs.h>
 }
 #include <dmlc/filesystem.h>
+
+#include <vector>
+#include <string>
 
 namespace dmlc {
 namespace io {

--- a/src/io/indexed_recordio_split.cc
+++ b/src/io/indexed_recordio_split.cc
@@ -1,9 +1,9 @@
 // Copyright by Contributors
-#include <algorithm>
-#include <fstream>
 #include <dmlc/recordio.h>
 #include <dmlc/logging.h>
 #include <dmlc/io.h>
+#include <algorithm>
+#include <fstream>
 #include "./indexed_recordio_split.h"
 
 namespace dmlc {

--- a/src/io/indexed_recordio_split.h
+++ b/src/io/indexed_recordio_split.h
@@ -6,14 +6,14 @@
 #ifndef DMLC_IO_INDEXED_RECORDIO_SPLIT_H_
 #define DMLC_IO_INDEXED_RECORDIO_SPLIT_H_
 
-#include <vector>
-#include <string>
-#include <utility>
-#include <random>
-#include <cstdio>
-#include <cstring>
 #include <dmlc/io.h>
 #include <dmlc/recordio.h>
+#include <vector>
+#include <cstdio>
+#include <string>
+#include <cstring>
+#include <utility>
+#include <random>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/input_split_base.cc
+++ b/src/io/input_split_base.cc
@@ -1,7 +1,7 @@
 // Copyright by Contributors
-#include <algorithm>
 #include <dmlc/logging.h>
 #include <dmlc/common.h>
+#include <algorithm>
 #include "./line_split.h"
 
 #if DMLC_USE_REGEX

--- a/src/io/input_split_base.h
+++ b/src/io/input_split_base.h
@@ -7,13 +7,13 @@
 #ifndef DMLC_IO_INPUT_SPLIT_BASE_H_
 #define DMLC_IO_INPUT_SPLIT_BASE_H_
 
+#include <dmlc/io.h>
+#include <dmlc/filesystem.h>
+#include <cstdio>
+#include <cstring>
 #include <vector>
 #include <string>
 #include <algorithm>
-#include <cstdio>
-#include <cstring>
-#include <dmlc/io.h>
-#include <dmlc/filesystem.h>
 
 namespace dmlc {
 namespace io {

--- a/src/io/line_split.cc
+++ b/src/io/line_split.cc
@@ -1,7 +1,7 @@
 // Copyright by Contributors
-#include <algorithm>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
+#include <algorithm>
 #include "./line_split.h"
 
 namespace dmlc {

--- a/src/io/line_split.h
+++ b/src/io/line_split.h
@@ -7,11 +7,11 @@
 #ifndef DMLC_IO_LINE_SPLIT_H_
 #define DMLC_IO_LINE_SPLIT_H_
 
+#include <dmlc/io.h>
 #include <vector>
 #include <cstdio>
 #include <string>
 #include <cstring>
-#include <dmlc/io.h>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -1,11 +1,11 @@
 // Copyright by Contributors
 
-extern "C" {
-#include <errno.h>
-#include <sys/stat.h>
-}
 #include <dmlc/base.h>
 #include <dmlc/logging.h>
+#include <errno.h>
+extern "C" {
+#include <sys/stat.h>
+}
 #ifndef _WIN32
 extern "C" {
 #include <sys/types.h>

--- a/src/io/local_filesys.h
+++ b/src/io/local_filesys.h
@@ -7,8 +7,8 @@
 #ifndef DMLC_IO_LOCAL_FILESYS_H_
 #define DMLC_IO_LOCAL_FILESYS_H_
 
-#include <vector>
 #include <dmlc/filesystem.h>
+#include <vector>
 
 namespace dmlc {
 namespace io {

--- a/src/io/recordio_split.cc
+++ b/src/io/recordio_split.cc
@@ -1,7 +1,7 @@
 // Copyright by Contributors
-#include <algorithm>
 #include <dmlc/recordio.h>
 #include <dmlc/logging.h>
+#include <algorithm>
 #include "./recordio_split.h"
 
 namespace dmlc {

--- a/src/io/recordio_split.h
+++ b/src/io/recordio_split.h
@@ -7,12 +7,12 @@
 #ifndef DMLC_IO_RECORDIO_SPLIT_H_
 #define DMLC_IO_RECORDIO_SPLIT_H_
 
-#include <vector>
-#include <string>
-#include <cstdio>
-#include <cstring>
 #include <dmlc/io.h>
 #include <dmlc/recordio.h>
+#include <vector>
+#include <cstdio>
+#include <string>
+#include <cstring>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/s3_filesys.cc
+++ b/src/io/s3_filesys.cc
@@ -1,16 +1,6 @@
 // Copyright by Contributors
 extern "C" {
 #include <errno.h>
-}
-#include <string>
-#include <algorithm>
-#include <sstream>
-#include <iomanip>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-extern "C" {
 #include <curl/curl.h>
 #include <openssl/hmac.h>
 #include <openssl/buffer.h>
@@ -18,6 +8,14 @@ extern "C" {
 }
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <algorithm>
+#include <ctime>
+#include <sstream>
+#include <iomanip>
 
 #include "./s3_filesys.h"
 

--- a/src/io/s3_filesys.h
+++ b/src/io/s3_filesys.h
@@ -7,9 +7,9 @@
 #ifndef DMLC_IO_S3_FILESYS_H_
 #define DMLC_IO_S3_FILESYS_H_
 
+#include <dmlc/filesystem.h>
 #include <vector>
 #include <string>
-#include <dmlc/filesystem.h>
 
 namespace dmlc {
 namespace io {

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -7,13 +7,13 @@
 #ifndef DMLC_IO_SINGLE_FILE_SPLIT_H_
 #define DMLC_IO_SINGLE_FILE_SPLIT_H_
 
-#include <sys/stat.h>
-#include <string>
-#include <algorithm>
-#include <cstdio>
 #include <dmlc/base.h>
 #include <dmlc/io.h>
 #include <dmlc/logging.h>
+#include <sys/stat.h>
+#include <cstdio>
+#include <string>
+#include <algorithm>
 
 #ifdef _WIN32
 #define stat_struct __stat64

--- a/src/io/single_threaded_input_split.h
+++ b/src/io/single_threaded_input_split.h
@@ -2,9 +2,9 @@
 #ifndef DMLC_IO_SINGLE_THREADED_INPUT_SPLIT_H_
 #define DMLC_IO_SINGLE_THREADED_INPUT_SPLIT_H_
 
-#include <algorithm>
 #include <dmlc/threadediter.h>
 #include <dmlc/base.h>
+#include <algorithm>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/threaded_input_split.h
+++ b/src/io/threaded_input_split.h
@@ -7,11 +7,11 @@
 #ifndef DMLC_IO_THREADED_INPUT_SPLIT_H_
 #define DMLC_IO_THREADED_INPUT_SPLIT_H_
 
-#include <algorithm>
 #include <dmlc/base.h>
 // this code depends on c++11
 #if DMLC_ENABLE_STD_THREAD
 #include <dmlc/threadediter.h>
+#include <algorithm>
 #include "./input_split_base.h"
 
 namespace dmlc {

--- a/src/io/uri_spec.h
+++ b/src/io/uri_spec.h
@@ -9,12 +9,12 @@
 #ifndef DMLC_IO_URI_SPEC_H_
 #define DMLC_IO_URI_SPEC_H_
 
+#include <dmlc/common.h>
 #include <string>
 #include <sstream>
 #include <map>
 #include <vector>
 #include <utility>
-#include <dmlc/common.h>
 
 namespace dmlc {
 namespace io {

--- a/src/recordio.cc
+++ b/src/recordio.cc
@@ -1,9 +1,9 @@
 // Copyright by Contributors
 
-#include <algorithm>
 #include <dmlc/base.h>
 #include <dmlc/recordio.h>
 #include <dmlc/logging.h>
+#include <algorithm>
 
 
 namespace dmlc {


### PR DESCRIPTION
Cpplint 1.5.1 reverted changes made to 1.5.0 which necessitated #622. So reverting. This should fix the CI.

Related: https://github.com/microsoft/LightGBM/issues/3132#issuecomment-639347710