### PR TITLE
Fix name clash in CHECK macro

### DIFF
--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -194,9 +194,9 @@ DEFINE_CHECK_FUNC(_NE, !=)
 #pragma GCC diagnostic pop
 
 #define CHECK_BINARY_OP(name, op, x, y)                  \
-  if (auto err = dmlc::LogCheck##name(x, y))             \
+  if (auto __dmlc__log__err = dmlc::LogCheck##name(x, y))  \
       dmlc::LogMessageFatal(__FILE__, __LINE__).stream() \
-        << "Check failed: " << #x " " #op " " #y << *err << ": "
+        << "Check failed: " << #x " " #op " " #y << *__dmlc__log__err << ": "
 
 // Always-on checking
 #define CHECK(x)                                           \


### PR DESCRIPTION
Follow-up to #626 

Address https://github.com/dmlc/dmlc-core/commit/25aa415dc0f2ccd84f2c1bb1419dca5faae93a8e#r39900770. A downstream application may use a local variable named `err` and that would clash with the variable `err` used in DMLC logging. Rename the latter variable to `__dmlc__log__err`, which (I hope) is unlikely to be used in a downstream application.

@szha 

Related: [Library writers often use symbols with double underscores to avoid name clashes](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3400.html).

cc @okuvshynov @junrushao1994 @trivialfis 