### PR TITLE
[CI] Run apt update

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install Dependencies
         run: |
           if [[ $(uname) != "Darwin" ]]; then
+            sudo apt update
             sudo apt install doxygen libcurl4-openssl-dev gcc-5 g++-5
           else
             brew install libomp doxygen


### PR DESCRIPTION
Fixes failing CI.

https://github.com/dmlc/dmlc-core/pull/631/checks?check_run_id=1020959250

Err:12 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.9
  404  Not Found [IP: 52.177.174.250 80]
Fetched 33.6 MB in 3s (12.3 MB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.9_amd64.deb  404  Not Found [IP: 52.177.174.250 80]