### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -34,6 +34,6 @@ jobs:
       - name: googletest
         run: |
           if [[ "${{ matrix.task }}" == "s390x_test" ]]; then
-            docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           fi
           TASK=${{ matrix.task }} ./scripts/test_script.sh

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install Dependencies
         run: |
           if [[ $(uname) != "Darwin" ]]; then
+            sudo apt update
             sudo apt install doxygen libcurl4-openssl-dev gcc-5 g++-5
           else
             brew install libomp doxygen

--- a/scripts/s390x/Dockerfile
+++ b/scripts/s390x/Dockerfile
@@ -1,27 +1,26 @@
-FROM multiarch/debian-debootstrap:s390x-jessie
+FROM s390x/ubuntu:20.04
 
+# Environment
 ENV DEBIAN_FRONTEND noninteractive
-ENV GOSU_VERSION 1.10
+SHELL ["/bin/bash", "-c"]   # Use Bash as shell
 
-RUN uname -a
-# Add repositories for Debian Jessie
-RUN printf 'deb http://deb.debian.org/debian/ oldstable main contrib non-free\ndeb-src http://deb.debian.org/debian/ oldstable main contrib non-free\ndeb http://deb.debian.org/debian/ oldstable-updates main contrib non-free\ndeb-src http://deb.debian.org/debian/ oldstable-updates main contrib non-free\ndeb http://deb.debian.org/debian-security oldstable/updates main' > /etc/apt/sources.list
-RUN apt-get update && \
-  apt-get install -y --no-install-suggests --no-install-recommends \
-  build-essential \
-  gcc \
-  make \
-  git \
-  cmake \
-  ca-certificates && \
-  update-ca-certificates --fresh
+# Install all basic requirements
+RUN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends tar unzip wget git build-essential ninja-build \
+      cmake time python3 python3-pip python3-numpy python3-scipy python3-sklearn r-base && \
+    python3 -m pip install pytest hypothesis
+
+ENV GOSU_VERSION 1.10
 
 # Install lightweight sudo (not bound to TTY)
 RUN set -ex; \
-    wget --no-check-certificate -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" && \
     chmod +x /usr/local/bin/gosu && \
     gosu nobody true
 
+# Default entry-point to use if running locally
+# It will preserve attributes of created files
 COPY entrypoint.sh /scripts/
 
 WORKDIR /workspace


### PR DESCRIPTION
* Run `apt update` before running `apt install`. This fixes error from https://github.com/dmlc/dmlc-core/pull/631/checks?check_run_id=1020959250:
>Err:12 http://security.ubuntu.com/ubuntu bionic-updates/main amd64 libcurl4-openssl-dev amd64 7.58.0-2ubuntu3.9
404 Not Found [IP: 52.177.174.250 80]
>Fetched 33.6 MB in 3s (12.3 MB/s)
>E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.58.0-2ubuntu3.9_amd64.deb 404 Not Found [IP: 52.177.174.250 80]
* Update s390x container, since multiarch Debian is no longer available. Use `s390x/ubuntu` instead.