### PR TITLE
Allow the user to furnish their own CHECK() and LOG() macros

### DIFF
--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -13,8 +13,15 @@
 
 /*!
  * \def DMLC_USE_LOGGING_LIBRARY
- * Whether to use user-defined logging library. Change this to an
- * include path like <my/lib/logging.h> to replace DMLC's builtin logging.
+ * Whether to use user-defined logging library. If defined, dmlc will not define
+ * the macros CHECK() and LOG() and instead locate CHECK() and LOG()
+ * from the value of DMLC_USE_LOGGING_LIBRARY. The
+ * DMLC_USE_LOGGING_LIBRARY macro shall be of form <my_logging.h>:
+ *
+ * #define DMLC_USE_LOGGING_LIBRARY <my_logging.h>
+ *
+ * Make sure to define CHECK() and LOG() macros in the provided header;
+ * otherwise the build will fail.
  */
 
 /*!

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -12,6 +12,12 @@
 #endif
 
 /*!
+ * \def DMLC_USE_LOGGING_LIBRARY
+ * Whether to use user-defined logging library. Change this to an
+ * include path like <my/lib/logging.h> to replace DMLC's builtin logging.
+ */
+
+/*!
  * \brief whether throw dmlc::Error instead of
  *  directly calling abort when FATAL error occured
  *  NOTE: this may still not be perfect.

--- a/include/dmlc/base.h
+++ b/include/dmlc/base.h
@@ -11,12 +11,12 @@
 #define DMLC_USE_GLOG 0
 #endif
 
-/*!
- * \def DMLC_USE_LOGGING_LIBRARY
- * Whether to use user-defined logging library. If defined, dmlc will not define
- * the macros CHECK() and LOG() and instead locate CHECK() and LOG()
- * from the value of DMLC_USE_LOGGING_LIBRARY. The
- * DMLC_USE_LOGGING_LIBRARY macro shall be of form <my_logging.h>:
+/*
+ * The preprocessor definition DMLC_USE_LOGGING_LIBRARY determines whether to
+ * use a user-defined logging library. If defined, dmlc will not define the
+ * macros CHECK() and LOG() and instead locate CHECK() and LOG() from the value
+ * of DMLC_USE_LOGGING_LIBRARY. The DMLC_USE_LOGGING_LIBRARY macro shall be of
+ * form <my_logging.h>:
  *
  * #define DMLC_USE_LOGGING_LIBRARY <my_logging.h>
  *

--- a/include/dmlc/logging.h
+++ b/include/dmlc/logging.h
@@ -127,6 +127,15 @@ inline void InitLogging(const char* argv0) {
 }
 }  // namespace dmlc
 
+#elif defined DMLC_USE_LOGGING_LIBRARY
+
+#include DMLC_USE_LOGGING_LIBRARY
+namespace dmlc {
+inline void InitLogging(const char*) {
+  // DO NOTHING
+}
+}
+
 #else
 // use a light version of glog
 #include <assert.h>


### PR DESCRIPTION
This make DMLC compatible with libraries that do not want to use DMLC's builtin logging facilities. If `DMLC_USE_LOGGING_LIBRARY` is defined, it will be used in place of the builtin library. This definition must point to an include path like `<my/logging.h>`.