### PR TITLE
Comment out unused parameters.

### DIFF
--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -169,11 +169,11 @@ class InputSplit {
    *  size to the hinted value
    * \param chunk_size the chunk size
    */
-  virtual void HintChunkSize(size_t /*chunk_size*/) {}
+  virtual void HintChunkSize(size_t chunk_size) { (void)chunk_size; }
   /*! \brief get the total size of the InputSplit */
-  virtual size_t GetTotalSize(void) = 0;
+  virtual size_t GetTotalSize() = 0;
   /*! \brief reset the position of InputSplit to beginning */
-  virtual void BeforeFirst(void) = 0;
+  virtual void BeforeFirst() = 0;
   /*!
    * \brief get the next record, the returning value
    *   is valid until next call to NextRecord, NextChunk or NextBatch
@@ -227,11 +227,12 @@ class InputSplit {
    * \sa InputSplit::Create for definition of record
    * \sa RecordIOChunkReader to parse recordio content from out_chunk
    */
-  virtual bool NextBatch(Blob *out_chunk, size_t /*n_records*/) {
+  virtual bool NextBatch(Blob *out_chunk, size_t n_records) {
+    (void)n_records;
     return NextChunk(out_chunk);
   }
   /*! \brief destructor*/
-  virtual ~InputSplit(void) DMLC_THROW_EXCEPTION {}
+  virtual ~InputSplit() DMLC_THROW_EXCEPTION = default;
   /*!
    * \brief reset the Input split to a certain part id,
    *  The InputSplit will be pointed to the head of the new specified segment.

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -169,7 +169,7 @@ class InputSplit {
    *  size to the hinted value
    * \param chunk_size the chunk size
    */
-  virtual void HintChunkSize(size_t chunk_size) {}
+  virtual void HintChunkSize(size_t /*chunk_size*/) {}
   /*! \brief get the total size of the InputSplit */
   virtual size_t GetTotalSize(void) = 0;
   /*! \brief reset the position of InputSplit to beginning */
@@ -227,7 +227,7 @@ class InputSplit {
    * \sa InputSplit::Create for definition of record
    * \sa RecordIOChunkReader to parse recordio content from out_chunk
    */
-  virtual bool NextBatch(Blob *out_chunk, size_t n_records) {
+  virtual bool NextBatch(Blob *out_chunk, size_t /*n_records*/) {
     return NextChunk(out_chunk);
   }
   /*! \brief destructor*/

--- a/include/dmlc/io.h
+++ b/include/dmlc/io.h
@@ -232,7 +232,7 @@ class InputSplit {
     return NextChunk(out_chunk);
   }
   /*! \brief destructor*/
-  virtual ~InputSplit() DMLC_THROW_EXCEPTION = default;
+  virtual ~InputSplit(void) DMLC_THROW_EXCEPTION {}
   /*!
    * \brief reset the Input split to a certain part id,
    *  The InputSplit will be pointed to the head of the new specified segment.

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -25,7 +25,7 @@ struct nullopt_t {
   explicit nullopt_t(int a) {}
 #else
   /*! \brief dummy constructor */
-  constexpr explicit nullopt_t(int a) {}
+  constexpr explicit nullopt_t(int) {}
 #endif
 };
 

--- a/include/dmlc/parameter.h
+++ b/include/dmlc/parameter.h
@@ -348,7 +348,7 @@ class FieldAccessEntry {
    */
   virtual void Set(void *head, const std::string &value) const = 0;
   // check if value is OK
-  virtual void Check(void *head) const {}
+  virtual void Check(void */*head*/) const {}
   /*!
    * \brief get the string representation of value.
    * \param head the pointer to the head of the struct

--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -551,8 +551,8 @@ class Str2T<int32_t> {
    * \param end End of the string to convert
    * \return Converted value, as signed 32-bit integer
    */
-  static inline int32_t get(const char * begin, const char * end) {
-    return ParseSignedInt<int32_t>(begin, NULL, 10);
+  static inline int32_t get(const char * begin, const char* /*end*/) {
+    return ParseSignedInt<int32_t>(begin, nullptr, 10);
   }
 };
 
@@ -568,8 +568,8 @@ class Str2T<uint32_t> {
    * \param end End of the string to convert
    * \return Converted value, as unsigned 32-bit integer
    */
-  static inline uint32_t get(const char* begin, const char* end) {
-    return ParseUnsignedInt<uint32_t>(begin, NULL, 10);
+  static inline uint32_t get(const char* begin, const char* /*end*/) {
+    return ParseUnsignedInt<uint32_t>(begin, nullptr, 10);
   }
 };
 
@@ -585,8 +585,8 @@ class Str2T<int64_t> {
    * \param end End of the string to convert
    * \return Converted value, as signed 64-bit integer
    */
-  static inline int64_t get(const char * begin, const char * end) {
-    return ParseSignedInt<int64_t>(begin, NULL, 10);
+  static inline int64_t get(const char * begin, const char * /*end*/) {
+    return ParseSignedInt<int64_t>(begin, nullptr, 10);
   }
 };
 
@@ -602,8 +602,8 @@ class Str2T<uint64_t> {
    * \param end End of the string to convert
    * \return Converted value, as unsigned 64-bit integer
    */
-  static inline uint64_t get(const char * begin, const char * end) {
-    return ParseUnsignedInt<uint64_t>(begin, NULL, 10);
+  static inline uint64_t get(const char * begin, const char * /*end*/) {
+    return ParseUnsignedInt<uint64_t>(begin, nullptr, 10);
   }
 };
 
@@ -619,7 +619,7 @@ class Str2T<float> {
    * \param end End of the string to convert
    * \return Converted value, in float type
    */
-  static inline float get(const char * begin, const char * end) {
+  static inline float get(const char * begin, const char * /*end*/) {
     return atof(begin);
   }
 };
@@ -636,8 +636,8 @@ class Str2T<double> {
    * \param end End of the string to convert
    * \return Converted value, in double type
    */
-  static inline double get(const char * begin, const char * end) {
-    return strtod(begin, 0);
+  static inline double get(const char * begin, const char * /*end*/) {
+    return strtod(begin, nullptr);
   }
 };
 

--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -569,7 +569,8 @@ class Str2T<uint32_t> {
    * \param end End of the string to convert
    * \return Converted value, as unsigned 32-bit integer
    */
-  static inline uint32_t get(const char* begin, const char* /*end*/) {
+  static inline uint32_t get(const char* begin, const char* end) {
+    (void)end;
     return ParseUnsignedInt<uint32_t>(begin, nullptr, 10);
   }
 };
@@ -604,7 +605,8 @@ class Str2T<uint64_t> {
    * \param end End of the string to convert
    * \return Converted value, as unsigned 64-bit integer
    */
-  static inline uint64_t get(const char * begin, const char * /*end*/) {
+  static inline uint64_t get(const char * begin, const char * end) {
+    (void)end;
     return ParseUnsignedInt<uint64_t>(begin, nullptr, 10);
   }
 };

--- a/include/dmlc/strtonum.h
+++ b/include/dmlc/strtonum.h
@@ -551,7 +551,8 @@ class Str2T<int32_t> {
    * \param end End of the string to convert
    * \return Converted value, as signed 32-bit integer
    */
-  static inline int32_t get(const char * begin, const char* /*end*/) {
+  static inline int32_t get(const char * begin, const char* end) {
+    (void)end;
     return ParseSignedInt<int32_t>(begin, nullptr, 10);
   }
 };
@@ -585,7 +586,8 @@ class Str2T<int64_t> {
    * \param end End of the string to convert
    * \return Converted value, as signed 64-bit integer
    */
-  static inline int64_t get(const char * begin, const char * /*end*/) {
+  static inline int64_t get(const char * begin, const char * end) {
+    (void)end;
     return ParseSignedInt<int64_t>(begin, nullptr, 10);
   }
 };
@@ -619,7 +621,8 @@ class Str2T<float> {
    * \param end End of the string to convert
    * \return Converted value, in float type
    */
-  static inline float get(const char * begin, const char * /*end*/) {
+  static inline float get(const char * begin, const char * end) {
+    (void)end;
     return atof(begin);
   }
 };
@@ -636,7 +639,8 @@ class Str2T<double> {
    * \param end End of the string to convert
    * \return Converted value, in double type
    */
-  static inline double get(const char * begin, const char * /*end*/) {
+  static inline double get(const char * begin, const char * end) {
+    (void)end;
     return strtod(begin, nullptr);
   }
 };

--- a/src/io/cached_input_split.h
+++ b/src/io/cached_input_split.h
@@ -84,7 +84,7 @@ class CachedInputSplit : public InputSplit {
       iter_cached_.Recycle(&tmp_chunk_);
     }
   }
-  virtual void ResetPartition(unsigned part_index, unsigned num_parts) {
+  virtual void ResetPartition(unsigned /*part_index*/, unsigned /*num_parts*/) {
     LOG(FATAL) << "ResetPartition is not supported in CachedInputSplit";
   }
   virtual void HintChunkSize(size_t chunk_size) {

--- a/src/io/input_split_base.h
+++ b/src/io/input_split_base.h
@@ -97,7 +97,7 @@ class InputSplitBase : public InputSplit {
    * \return true if this object represents a text parser; false if it represents
    *         a binary parser
    */
-  virtual bool IsTextParser(void) = 0;
+  virtual bool IsTextParser() = 0;
   /*!
    * \brief fill the given
    *  chunk with new data without using internal
@@ -112,7 +112,7 @@ class InputSplitBase : public InputSplit {
    *  chunk with new batch of data without using internal
    *  temporary chunk
    */
-  virtual bool NextBatchEx(Chunk *chunk, size_t n_records) {
+  virtual bool NextBatchEx(Chunk *chunk, size_t /* n_records*/) {
     return NextChunkEx(chunk);
   }
 

--- a/src/io/single_file_split.h
+++ b/src/io/single_file_split.h
@@ -70,7 +70,7 @@ class SingleFileSplit : public InputSplit {
     CHECK(part_index == 0 && num_parts == 1);
     this->BeforeFirst();
   }
-  virtual void Write(const void *ptr, size_t size) {
+  virtual void Write(const void */*ptr*/, size_t /*size*/) {
     LOG(FATAL) << "InputSplit do not support write";
   }
   virtual bool NextRecord(Blob *out_rec) {


### PR DESCRIPTION
xgboost has been using extra compiler warnings on CI to catch some bugs like unused parameters.  This will ease effort.