### PR TITLE
Allow GNU Make user to opt out of using execinfo.h via flag DMLC_LOG_STACK_TRACE

### DIFF
--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -22,15 +22,17 @@
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
      && !defined(__RISCV__) && !defined(__hexagon__)
-#if DMLC_CXXABI_H_PRESENT && DMLC_EXECINFO_H_PRESENT
+  #if defined(DMLC_LOG_STACK_TRACE) && DMLC_LOG_STACK_TRACE
+  #define DMLC_EXECINFO_H <execinfo.h>
+  #else
+  #define DMLC_EXECINFO_H
+  #endif
   #ifndef DMLC_LOG_STACK_TRACE
   #define DMLC_LOG_STACK_TRACE 1
   #endif
   #ifndef DMLC_LOG_STACK_TRACE_SIZE
   #define DMLC_LOG_STACK_TRACE_SIZE 10
   #endif
-  #define DMLC_EXECINFO_H <execinfo.h>
-#endif
 #endif
 
 /* default logic for detecting existence of nanosleep() */

--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -22,6 +22,7 @@
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
      && !defined(__RISCV__) && !defined(__hexagon__)
+#if DMLC_CXXABI_H_PRESENT && DMLC_EXECINFO_H_PRESENT
   #ifndef DMLC_LOG_STACK_TRACE
   #define DMLC_LOG_STACK_TRACE 1
   #endif
@@ -29,6 +30,7 @@
   #define DMLC_LOG_STACK_TRACE_SIZE 10
   #endif
   #define DMLC_EXECINFO_H <execinfo.h>
+#endif
 #endif
 
 /* default logic for detecting existence of nanosleep() */

--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -22,13 +22,15 @@
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
      && !defined(__RISCV__) && !defined(__hexagon__)
-  #if defined(DMLC_LOG_STACK_TRACE) && DMLC_LOG_STACK_TRACE
-  #define DMLC_EXECINFO_H <execinfo.h>
+  #if !defined(DMLC_LOG_STACK_TRACE)
+    #define DMLC_LOG_STACK_TRACE 1
+    #define DMLC_EXECINFO_H <execinfo.h>
   #else
-  #define DMLC_EXECINFO_H
-  #endif
-  #ifndef DMLC_LOG_STACK_TRACE
-  #define DMLC_LOG_STACK_TRACE 1
+    #if DMLC_LOG_STACK_TRACE
+      #define DMLC_EXECINFO_H <execinfo.h>
+    #else
+      #define DMLC_EXECINFO_H
+    #endif
   #endif
   #ifndef DMLC_LOG_STACK_TRACE_SIZE
   #define DMLC_LOG_STACK_TRACE_SIZE 10


### PR DESCRIPTION
Some platforms (e.g. OpenWRT) do not have `execinfo.h` in their SDK.

We should check that `cxxabi.h` and  `execinfo.h` are present before enabling `DMLC_LOG_STACK_TRACE` by default in [build_config_default.h](https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/build_config_default.h#L25)

This check is already done in [cmake/build_config.h.in](https://github.com/dmlc/dmlc-core/blob/main/cmake/build_config.h.in#L13).
To be consistent we should also do it in [build_config_default.h](https://github.com/dmlc/dmlc-core/blob/main/include/dmlc/build_config_default.h#L25)