### PR TITLE
Move constructor is added to support dmlc::optional<T>

### DIFF
--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -72,6 +72,8 @@ class optional {
 public:
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
+   /*! \brief constructs an object that does contain a nullopt value. */
+  optional(nullopt_t) noexcept : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) = default;

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -74,16 +74,7 @@ public:
   optional() : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
-  optional(const optional &other) {
-    if (!other.has_value()) {
-      reset();
-    } else if (has_value()) {
-      **this = *other;
-    } else {
-      new (&val) T(*other);
-      is_none = false;
-    }
-  };
+  optional(const optional &other) = default;
   /*! \brief constructs an optional object that contains a value, initialized as
    * if direct-initializing */
   template <typename... Args>

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -233,22 +233,22 @@ public:
     return *reinterpret_cast<T *>(&val);
   }
   const T &value() const & {
-    if (has_value()) {
+    if (is_none) {
       throw std::logic_error("bad optional access");
     }
     return *reinterpret_cast<const T *>(&val);
   }
   T &&value() && {
-    if (has_value()) {
+    if (is_none) {
       throw std::logic_error("bad optional access");
     }
-    return std::move(*val);
+    return std::move(value());
   }
   const T &&value() const && {
-    if (has_value()) {
+    if (is_none) {
       throw std::logic_error("bad optional access");
     }
-    return std::move(*val);
+    return std::move(value());
   }
   /*! \brief whether this object is holding a value */
   explicit operator bool() const { return !is_none; }

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -29,7 +29,7 @@ struct nullopt_t {
 #endif
 };
 
-/*! \brief Assign null to optional: optional<T> x = nullopt; */
+/*! Assign null to optional: optional<T> x = nullopt; */
 constexpr const nullopt_t nullopt = nullopt_t(0);
 /*! \brief C++14 aliases */
 template <typename T> using decay_t = typename std::decay<T>::type;

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -72,8 +72,6 @@ class optional {
 public:
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
-  /*! \brief construct an optional object with nullopt. */
-  optional(nullopt_t) : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) {

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -46,7 +46,7 @@ class optional {
   /*! \brief construct an optional object that contains no value */
   optional() : is_none(true) {}
   /*! \brief construct an optional object with value */
-  optional(const T& value) {
+  explicit optional(const T& value) {
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -40,7 +40,7 @@ using enable_if_t = typename std::enable_if<B, T>::type;
  * dmlc::optional. A tag type to tell constructor to construct its value in-place
  */
 struct in_place_t {
-  explicit in_place_t() = default;
+  in_place_t() = default;
 };
 /*! \brief A tag to tell constructor to construct its value in-place */
 static constexpr in_place_t in_place{};
@@ -74,12 +74,12 @@ using enable_constructor_from_value =
  */
 template <typename T>
 class optional {
-public:
+ public:
   using value_type = T;
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
-   /*! \brief constructs an object that does contain a nullopt value. */
-  optional(dmlc::nullopt_t) noexcept : is_none(true) {}
+  /*! \brief constructs an object that does contain a nullopt value. */
+  explicit optional(dmlc::nullopt_t) noexcept : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) = default;
@@ -120,7 +120,7 @@ public:
   template <typename U = value_type,
             enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr,
             enable_constructor_from_value<T, U> * = nullptr>
-  optional(U &&other) noexcept {
+  optional(U &&other) noexcept {  // NOLINT(*)
     new (&val) T(std::forward<U>(other));
     is_none = false;
   }
@@ -201,7 +201,7 @@ public:
 #pragma GCC diagnostic push
 #if __GNUC__ >= 6
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif   
+#endif
     (optional<T>(other)).swap(*this);
     return *this;
 #pragma GCC diagnostic pop

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -31,7 +31,9 @@ struct nullopt_t {
 
 /*! Assign null to optional: optional<T> x = nullopt; */
 constexpr const nullopt_t nullopt = nullopt_t(0);
-
+/*! C++14 aliases */
+template <typename T> using decay_t = typename std::decay<T>::type;
+template <bool B, typename T = void> using enable_if_t = typename std::enable_if<B, T>::type;
 /*!
  * \brief c++17 compatible optional class.
  *
@@ -77,6 +79,12 @@ class optional {
       new (&val) T(std::move(*other));
       is_none = true;
     }
+  }
+  /* \brief Converting move constructor: to construct an optional object of type T that contain a value */
+  template <class U = T, enable_if_t<std::is_convertible<U &&, T>::value> * = nullptr>
+  optional(U && value) {
+      new (&val) T(std::forward<U>(value));
+      is_none = true;
   }
   /*! \brief reset */
   void reset() noexcept {

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -73,7 +73,7 @@ public:
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
    /*! \brief constructs an object that does contain a nullopt value. */
-  optional(nullopt_t) noexcept : is_none(true) {}
+  optional(dmlc::nullopt_t) noexcept : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) = default;

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -40,7 +40,7 @@ using enable_if_t = typename std::enable_if<B, T>::type;
  * dmlc::optional. A tag type to tell constructor to construct its value in-place
  */
 struct in_place_t {
-  in_place_t() = default;
+  explicit in_place_t() = default;  // NOLINT(*)
 };
 /*! \brief A tag to tell constructor to construct its value in-place */
 static constexpr in_place_t in_place{};
@@ -79,7 +79,7 @@ class optional {
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
   /*! \brief constructs an object that does contain a nullopt value. */
-  explicit optional(dmlc::nullopt_t) noexcept : is_none(true) {}
+  optional(dmlc::nullopt_t) noexcept : is_none(true) {} // NOLINT(*)
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) = default;

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -73,7 +73,7 @@ public:
   /*! \brief constructs an object that does not contain a value. */
   optional() : is_none(true) {}
   /*! \brief construct an optional object with nullopt. */
-  optional(nullopt_t) noexcept {}
+  optional(nullopt_t) : is_none(true) {}
   /*! \brief copy constructor, if other contains a value, then stored value is
    * direct-intialized with it. */
   optional(const optional &other) {

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -198,8 +198,13 @@ public:
    *  \return return self to support chain assignment
    */
   optional<T>& operator=(const optional<T> &other) {
+#pragma GCC diagnostic push
+#if __GNUC__ >= 6
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif   
     (optional<T>(other)).swap(*this);
     return *this;
+#pragma GCC diagnostic pop
   }
   /*! \brief clear the value this object is holding.
    *         optional<T> x = nullopt;

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -54,10 +54,10 @@ using enable_constructor_from_other =
     enable_if_t<std::is_constructible<T, Other>::value &&
                 !std::is_constructible<T, optional<U> &>::value &&
                 !std::is_constructible<T, optional<U> &&>::value &&
-                !std::is_constructible<T, const optional<U> &>::value &&
-                !std::is_constructible<T, const optional<U> &&>::value &&
                 !std::is_convertible<optional<U> &, T>::value &&
                 !std::is_convertible<optional<U> &&, T>::value &&
+                !std::is_constructible<T, const optional<U> &>::value &&
+                !std::is_constructible<T, const optional<U> &&>::value &&
                 !std::is_convertible<const optional<U> &, T>::value &&
                 !std::is_convertible<const optional<U> &&, T>::value>;
 /*!
@@ -235,11 +235,29 @@ public:
   /*! \brief return the holded value.
    *         throws std::logic_error if holding no value
    */
-  const T& value() const {
+  T &value() & {
     if (is_none) {
       throw std::logic_error("bad optional access");
     }
-    return *reinterpret_cast<const T*>(&val);
+    return *reinterpret_cast<T *>(&val);
+  }
+  const T &value() const & {
+    if (has_value()) {
+      throw std::logic_error("bad optional access");
+    }
+    return *reinterpret_cast<const T *>(&val);
+  }
+  T &&value() && {
+    if (has_value()) {
+      throw std::logic_error("bad optional access");
+    }
+    return std::move(*val);
+  }
+  const T &&value() const && {
+    if (has_value()) {
+      throw std::logic_error("bad optional access");
+    }
+    return std::move(*val);
   }
   /*! \brief whether this object is holding a value */
   explicit operator bool() const { return !is_none; }

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -42,7 +42,6 @@ constexpr const nullopt_t nullopt = nullopt_t(0);
 template<typename T>
 class optional {
  public:
-   using value_type = T;
   /*! \brief construct an optional object that contains no value */
   optional() : is_none(true) {}
   /*! \brief construct an optional object with value */

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -6,6 +6,37 @@
 #include <dmlc/parameter.h>
 #include <gtest/gtest.h>
 
+#include <vector>
+
+TEST(Constructors, constructors) {
+  dmlc::optional<int> o1;
+  CHECK(!o1);
+
+  dmlc::optional<int> o2 = dmlc::nullopt;
+  CHECK(!o2);
+
+  dmlc::optional<int> o3 = 42;
+  CHECK_EQ(*o3, 42);
+
+  dmlc::optional<int> o4 = o3;
+  CHECK_EQ(*o4, 42);
+
+  dmlc::optional<int> o5 = o1;
+  CHECK(!o5);
+
+  dmlc::optional<int> o6 = std::move(o3);
+  CHECK_EQ(*o6, 42);
+
+  dmlc::optional<int> o7 = 42;
+  CHECK_EQ(*o7, 42);
+
+  dmlc::optional<int> o8 = o7;
+  CHECK_EQ(*o8, 42);
+
+  dmlc::optional<int> o9 = std::move(o7);
+  CHECK_EQ(*o9, 42);
+
+}
 
 TEST(Optional, basics_int) {
   dmlc::optional<int> x;

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -11,6 +11,10 @@
 TEST(Constructors, constructors) {
   dmlc::optional<int> o1;
   CHECK(!o1);
+
+  dmlc::optional<int> o2 = dmlc::nullopt;
+  CHECK(!o2);
+
   dmlc::optional<int> o3 = 42;
   CHECK_EQ(*o3, 42);
 
@@ -32,6 +36,14 @@ TEST(Constructors, constructors) {
   dmlc::optional<int> o9 = std::move(o7);
   CHECK_EQ(*o9, 42);
 
+  dmlc::optional<int> o10, o11 = 1, o12 = o11;
+  dmlc::optional<std::string> o13(dmlc::in_place, {'a', 'b', 'c'});
+  CHECK_EQ(*o11, 1);
+  CHECK_EQ(*o12, 1);
+  CHECK_EQ(*o13, "abc");
+
+  dmlc::optional<std::string> o14(dmlc::in_place, 3, 'A');
+  CHECK_EQ(*o14, "AAA");
 }
 
 TEST(Optional, basics_int) {

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -11,10 +11,6 @@
 TEST(Constructors, constructors) {
   dmlc::optional<int> o1;
   CHECK(!o1);
-
-  dmlc::optional<int> o2 = dmlc::nullopt;
-  CHECK(!o2);
-
   dmlc::optional<int> o3 = 42;
   CHECK_EQ(*o3, 42);
 

--- a/test/unittest/unittest_optional.cc
+++ b/test/unittest/unittest_optional.cc
@@ -8,7 +8,7 @@
 
 #include <vector>
 
-TEST(Constructors, constructors) {
+TEST(Optional, constructors) {
   dmlc::optional<int> o1;
   CHECK(!o1);
 
@@ -44,6 +44,19 @@ TEST(Constructors, constructors) {
 
   dmlc::optional<std::string> o14(dmlc::in_place, 3, 'A');
   CHECK_EQ(*o14, "AAA");
+}
+
+TEST(Optional, in_place) {
+  dmlc::optional<int> o1{dmlc::in_place};
+  CHECK(*o1 == 0);
+
+  dmlc::optional<std::vector<int>> o2(dmlc::in_place, {0, 1});
+  CHECK((*o2)[0] == 0);
+  CHECK((*o2)[1] == 1);
+
+  dmlc::optional<std::tuple<int, int>> o3(dmlc::in_place, 0, 1);
+  CHECK(std::get<0>(*o3) == 0);
+  CHECK(std::get<1>(*o3) == 1);
 }
 
 TEST(Optional, basics_int) {


### PR DESCRIPTION
## Description ##
The class template std::optional manages an optional contained value, i.e. a value that may or may not be present. In this pull request, a few things were implemented, such as extended series of constructors and a function of value. Mainly, this pull request is a realization of changes that have an impact on constructors, as follows, (upgrade dmlc::optional<T> constructors):

1. constructor to construct an object that does not contain a value,
2. constructor to construct an object that contains a nullptr value,
3. constructs an optional object that contains a value, initialized as if direct-initializing:`
3. move constructor: If other contains a value, then the stored value is direct-intialized with it.
     `optional(optional &&other) noexcept() { }`
4. move constructor: constructs the stored value with value with `other`parameter.
    `optional(U &&other) noexcept { }`

Upgrade: dmlc::optional<T> value
1.` T &value() &`
2. `const T &value() const &`
3. `T &&value() &`
4. `const T && value() const &&`