### PR TITLE
To avoid warning message, a LATEX_SORUCE_CODE is disabled, for a MacOS it has become obsolete 

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1691,7 +1691,7 @@ LATEX_HIDE_INDICES     = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-LATEX_SOURCE_CODE      = NO
+# LATEX_SOURCE_CODE      = NO
 
 # The LATEX_BIB_STYLE tag can be used to specify the style to use for the
 # bibliography, e.g. plainnat, or ieeetr. See


### PR DESCRIPTION
Doxygen fails on a macOS because LATEX_SOURCE_CODE's tag has become obsolete. The issue comes from #658. A LATEX_SOURCE_CODE is disabled in this pull request.
```cpp
+ exit 1
warning: Tag 'LATEX_SOURCE_CODE' at line 1694 of file 'doc/Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
Error: Process completed with exit code 1.
```