### PR TITLE
Python 3's: avoid %-formatting, f-strings as a new way

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -39,12 +39,11 @@ class LintHelper(object):
         if len(result_map) == 0:
             return 0
         npass = len([x for k, x in result_map.items() if len(x) == 0])
-        strm.write('=====%d/%d %s files passed check=====\n' % (npass, len(result_map), ftype))
+        strm.write(f'====={npass}/{len(result_map)} {ftype} files passed check=====\n')
         for fname, emap in result_map.items():
             if len(emap) == 0:
                 continue
-            strm.write('%s: %d Errors of %d Categories map=%s\n' % (
-                fname, sum(emap.values()), len(emap), str(emap)))
+            strm.write(f'{fname}: {sum(emap.values())} Errors of {len(emap)} Categories map={str(emap)}\n')
         return len(result_map) - npass
 
     def __init__(self):
@@ -111,7 +110,7 @@ class LintHelper(object):
         if nerr == 0:
             strm.write('All passed!\n')
         else:
-            strm.write('%d files failed lint\n' % nerr)
+            strm.write(f'{nerr} files failed lint\n')
         return nerr
 
 # singleton helper for lint check

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -43,7 +43,8 @@ class LintHelper(object):
         for fname, emap in result_map.items():
             if len(emap) == 0:
                 continue
-            strm.write(f'{fname}: {sum(emap.values())} Errors of {len(emap)} Categories map={str(emap)}\n')
+            strm.write(
+                f'{fname}: {sum(emap.values())} Errors of {len(emap)} Categories map={str(emap)}\n')
         return len(result_map) - npass
 
     def __init__(self):


### PR DESCRIPTION
Python 3's f-Strings: An Improved String Formatting Syntax; Issue comes from: #658

CI jobs fail because %-formatting is obsolete: an error message:
```Shell
+ make lint
scripts/lint.py dmlc "all" include src scripts --exclude_path include/dmlc/concurrentqueue.h include/dmlc/blockingconcurrentqueue.h
************* Module lint
 scripts/lint.py:42: convention (C0209, consider-using-f-string, LintHelper._print_summary_map) Formatting a regular string which could be a f-string
 scripts/lint.py:46: convention (C0209, consider-using-f-string, LintHelper._print_summary_map) Formatting a regular string which could be a f-string
 scripts/lint.py:114: convention (C0209, consider-using-f-string, LintHelper.print_summary) Formatting a regular string which could be a f-string
 ```