### PR TITLE
Fix unity build.

### DIFF
--- a/test/unittest/unittest_threaditer.cc
+++ b/test/unittest/unittest_threaditer.cc
@@ -4,9 +4,11 @@
 #include <gtest/gtest.h>
 #include <dmlc/threadediter.h>
 
+#include "unittest_threaditer.h"
+
 using namespace dmlc;
 namespace producer_test {
-inline void delay(int sleep) {
+void delay(int sleep) {
   if (sleep < 0) {
     int d = rand() % (-sleep);
     std::this_thread::sleep_for(std::chrono::milliseconds(d));
@@ -14,7 +16,6 @@ inline void delay(int sleep) {
     std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
   }
 }
-
 // int was only used as example, in real life
 // use big data blob
 struct IntProducer : public ThreadedIter<int>::Producer {

--- a/test/unittest/unittest_threaditer.h
+++ b/test/unittest/unittest_threaditer.h
@@ -1,0 +1,6 @@
+#include <chrono>
+#include <thread>
+
+namespace producer_test {
+void delay(int sleep);
+}  // namespace producer_test

--- a/test/unittest/unittest_threaditer_exc_handling.cc
+++ b/test/unittest/unittest_threaditer_exc_handling.cc
@@ -4,6 +4,8 @@
 #include <dmlc/threadediter.h>
 #include <gtest/gtest.h>
 
+#include "unittest_threaditer.h"
+
 enum ExcType {
   kDMLCException,
   kStdException,
@@ -11,15 +13,6 @@ enum ExcType {
 
 using namespace dmlc;
 namespace producer_test {
-inline void delay(int sleep) {
-  if (sleep < 0) {
-    int d = rand() % (-sleep);
-    std::this_thread::sleep_for(std::chrono::milliseconds(d));
-  } else {
-    std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
-  }
-}
-
 // int was only used as example, in real life
 // use big data blob
 struct IntProducerNextExc : public ThreadedIter<int>::Producer {


### PR DESCRIPTION
Related: https://github.com/dmlc/xgboost/pull/7139 .

Also removes duplicated implementation of `delay`.