### PR TITLE
Revert copy-constructor modification which causes TVM segfaults

### DIFF
--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -80,9 +80,18 @@ class optional {
   optional() : is_none(true) {}
   /*! \brief constructs an object that does contain a nullopt value. */
   optional(dmlc::nullopt_t) noexcept : is_none(true) {} // NOLINT(*)
-  /*! \brief copy constructor, if other contains a value, then stored value is
-   * direct-intialized with it. */
-  optional(const optional &other) = default;
+  /*! \brief construct an optional object with another optional object */
+  optional(const optional<T>& other) {
+#pragma GCC diagnostic push
+#if __GNUC__ >= 6
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+    is_none = other.is_none;
+    if (!is_none) {
+      new (&val) T(other.value());
+    }
+#pragma GCC diagnostic pop
+  }
   /*! \brief move constructor: If other contains a value, then stored value is
    * direct-intialized with it. */
   optional(optional &&other) noexcept(


### PR DESCRIPTION
See https://github.com/dmlc/dmlc-core/pull/658

Unfortunately I don't have any more information on why this happens, but tvm is now blocked in updating dmlc-core. I had a unittest that could pass previously, but didn't pass after #658--but, a) I unfortunately lost it in auto-updating a submodule b) don't know if that was really the problem because most of these single-arg constructors aren't marked explicit.

cc @tqchen @mozga-intel @szha 