### PR TITLE
Upgrade Google Test to 1.11.0

### DIFF
--- a/cmake/gtest_cmake.in
+++ b/cmake/gtest_cmake.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.10.0
+    GIT_TAG release-1.11.0
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""

--- a/scripts/packages.mk
+++ b/scripts/packages.mk
@@ -5,15 +5,15 @@
 
 # rules for gtest
 /tmp/gtest/include/gtest:
-	rm -rf gtest release-1.10.0.zip
-	wget https://github.com/google/googletest/archive/release-1.10.0.zip
-	unzip release-1.10.0.zip
-	mv googletest-release-1.10.0 gtest
+	rm -rf gtest release-1.11.0.zip
+	wget https://github.com/google/googletest/archive/release-1.11.0.zip
+	unzip release-1.11.0.zip
+	mv googletest-release-1.11.0 gtest
 	cd gtest; $(CXX) $(CXXFLAGS) -std=c++11 -Igoogletest -Igoogletest/include -pthread -c googletest/src/gtest-all.cc -o gtest-all.o; cd ..
 	$(AR) -rv libgtest.a gtest/gtest-all.o
 	mkdir -p /tmp/gtest/include /tmp/gtest/lib
 	cp -r gtest/googletest/include/gtest /tmp/gtest/include
 	mv libgtest.a /tmp/gtest/lib
-	rm -rf release-1.10.0.zip
+	rm -rf release-1.11.0.zip
 
 gtest: | /tmp/gtest/include/gtest


### PR DESCRIPTION
With newer versions of gcc, gtest 1.10.0 causes a compile warning/error:
```console
In file included from /home/rou/src/xgboost-cpp/cmake-build-debug/googletest-src/googletest/src/gtest-all.cc:42:
/home/rou/src/xgboost-cpp/cmake-build-debug/googletest-src/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
/home/rou/src/xgboost-cpp/cmake-build-debug/googletest-src/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
 1301 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/rou/src/xgboost-cpp/cmake-build-debug/googletest-src/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
 1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
/home/rou/src/xgboost-cpp/cmake-build-debug/googletest-src/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
 1299 |   int dummy;
      |       ^~~~~
cc1plus: all warnings being treated as errors
```

@hcho3 @trivialfis