### PR TITLE
Add Necessary Checks and Definitions to Build on QNX

### DIFF
--- a/include/dmlc/build_config_default.h
+++ b/include/dmlc/build_config_default.h
@@ -21,7 +21,8 @@
      && !defined(__sun) && !defined(__SVR4)\
      && !(defined __MINGW64__) && !(defined __ANDROID__))\
      && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)\
-     && !defined(__RISCV__) && !defined(__hexagon__)
+     && !defined(__RISCV__) && !defined(__hexagon__)\
+     && !defined(__QNX__)
   #if !defined(DMLC_LOG_STACK_TRACE)
     #define DMLC_LOG_STACK_TRACE 1
     #define DMLC_EXECINFO_H <execinfo.h>

--- a/include/dmlc/endian.h
+++ b/include/dmlc/endian.h
@@ -21,6 +21,9 @@
   #elif defined(__FreeBSD__) || defined(__OpenBSD__)
     #include <sys/endian.h>
     #define DMLC_LITTLE_ENDIAN (_BYTE_ORDER == _LITTLE_ENDIAN)
+  #elif defined(__QNX__)
+    #include <sys/param.h>
+    #define DMLC_LITTLE_ENDIAN (BYTE_ORDER == LITTLE_ENDIAN)
   #elif defined(__EMSCRIPTEN__) || defined(__hexagon__)
     #define DMLC_LITTLE_ENDIAN 1
   #elif defined(__sun) || defined(sun)


### PR DESCRIPTION
Recently we do the TVM deploy work on QNX, and found 2 places that dmlc-core haven't handle correctly.
1. Backtraces
Even through QNX have a library named "libbacktrace" can do the job, but the [QNX official document](http://www.qnx.com/developers/docs/7.0.0/index.html#com.qnx.doc.neutrino.technotes/topic/backtrace.html) notice that it is an unsupported feature, in addition the API is very different with those of file "execinfo.h", so we think maybe just don't do the bacetrace on QNX is a better solution.
3. Endian
Refer to https://github.com/protocolbuffers/protobuf/pull/10080, endian can be detected on QNX correctly.