### PR TITLE
Consistently use lowercase names for Windows libraries and headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ if(USE_OPENMP)
 endif()
 
 if(WIN32 AND (NOT MSVC))  # On Windows, link Shlwapi.lib for non-MSVC compilers
-  target_link_libraries(dmlc PRIVATE Shlwapi)
+  target_link_libraries(dmlc PRIVATE shlwapi)
 endif()
 
 # Check location of clock_gettime; if it's in librt, link it

--- a/include/dmlc/filesystem.h
+++ b/include/dmlc/filesystem.h
@@ -18,8 +18,8 @@
 #ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
-#include <Shlwapi.h>
-#pragma comment(lib, "Shlwapi.lib")
+#include <shlwapi.h>
+#pragma comment(lib, "shlwapi.lib")
 #else  // _WIN32
 #include <unistd.h>
 #include <sys/stat.h>

--- a/src/io/local_filesys.cc
+++ b/src/io/local_filesys.cc
@@ -13,7 +13,7 @@ extern "C" {
 }
 #define stat_struct stat
 #else  // _WIN32
-#include <Windows.h>
+#include <windows.h>
 #define stat _stat64
 #define stat_struct __stat64
 #endif  // _WIN32


### PR DESCRIPTION
MinGW consistently uses lowercase names for all libraries and header files, and
this toolchain is often employed to build libraries for Windows on Linux
systems, which typically use case-sensitive file systems.