### PR TITLE
CMake config: Propagate needed cxx standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ if(USE_AZURE)
 endif()
 
 add_library(dmlc ${SOURCE})
+target_compile_features(dmlc PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
 # Sanitizer
 if (DMLC_USE_SANITIZER)


### PR DESCRIPTION
Projects that using this lib also needs c++11/14