### PR TITLE
Get rid of std::iterator which is deprecated in C++17

### DIFF
--- a/include/dmlc/config.h
+++ b/include/dmlc/config.h
@@ -117,9 +117,14 @@ class Config {
   /*!
    * \brief iterator class
    */
-  class ConfigIterator : public std::iterator< std::input_iterator_tag, ConfigEntry > {
+  class ConfigIterator {
     friend class Config;
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = ConfigEntry;
+    using difference_type = std::ptrdiff_t;
+    using pointer = ConfigEntry*;
+    using reference = ConfigEntry&;
     /*!
      * \brief copy constructor
      */


### PR DESCRIPTION
XGBoost recently moved to C++17 (https://github.com/dmlc/xgboost/pull/8853) which now shows a deprecation warning for calling `std::iterator`. See https://www.fluentcpp.com/2018/05/08/std-iterator-deprecated/.