### PR TITLE
Don't populate labels if label column is not specified in csv parser

### DIFF
--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -89,7 +89,6 @@ ParseBlock(const char *begin,
     const char* p = lbegin;
     int column_index = 0;
     IndexType idx = 0;
-    DType label = DType(std::numeric_limits<real_t>::quiet_NaN());
     real_t weight = std::numeric_limits<real_t>::quiet_NaN();
 
     while (p != lend) {
@@ -110,7 +109,7 @@ ParseBlock(const char *begin,
       }
 
       if (column_index == param_.label_column) {
-        label = v;
+        out->label.push_back(v);
       } else if (std::is_same<DType, real_t>::value
                  && column_index == param_.weight_column) {
         weight = v;
@@ -135,9 +134,6 @@ ParseBlock(const char *begin,
     // skip empty line
     while ((*lend == '\n' || *lend == '\r') && lend != end) ++lend;
     lbegin = lend;
-    if (!std::isnan(label)) {
-      out->label.push_back(label);
-    }
     if (!std::isnan(weight)) {
       out->weight.push_back(weight);
     }

--- a/src/data/csv_parser.h
+++ b/src/data/csv_parser.h
@@ -42,9 +42,8 @@ struct CSVParserParam : public Parameter<CSVParserParam> {
 
 /*!
  * \brief CSVParser, parses a dense csv format.
- *  Currently is a dummy implementation, when label column is not specified.
  *  All columns are treated as real dense data.
- *  label will be assigned to 0.
+ *  Label will be empty if the label column is not specified.
  *
  *  This should be extended in future to accept arguments of column types.
  */
@@ -90,7 +89,7 @@ ParseBlock(const char *begin,
     const char* p = lbegin;
     int column_index = 0;
     IndexType idx = 0;
-    DType label = DType(0.0f);
+    DType label = DType(std::numeric_limits<real_t>::quiet_NaN());
     real_t weight = std::numeric_limits<real_t>::quiet_NaN();
 
     while (p != lend) {
@@ -136,13 +135,15 @@ ParseBlock(const char *begin,
     // skip empty line
     while ((*lend == '\n' || *lend == '\r') && lend != end) ++lend;
     lbegin = lend;
-    out->label.push_back(label);
+    if (!std::isnan(label)) {
+      out->label.push_back(label);
+    }
     if (!std::isnan(weight)) {
       out->weight.push_back(weight);
     }
     out->offset.push_back(out->index.size());
   }
-  CHECK(out->label.size() + 1 == out->offset.size());
+  CHECK(out->label.size() == 0 || out->label.size() + 1 == out->offset.size());
   CHECK(out->weight.size() == 0 || out->weight.size() + 1 == out->offset.size());
 }
 }  // namespace data


### PR DESCRIPTION
Right now the CSV parser sets labels to 0 if the label column is not specified (or set to -1). This is surprising to the user and leads to cryptic error messages. It's probably better to just leave the labels as empty if not specified.

For vertical federated learning, we may have workers that don't have access to the label, so this would enable them to parse csv shards without erroneously setting labels to 0.