### PR TITLE
Remove deprecated `throw()`

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -19,8 +19,8 @@ struct Token {
 class TokenizeError : public exception {
  public:
   explicit TokenizeError(const string& msg = "tokenize error"): msg_(msg) { }
-  ~TokenizeError() throw() {}
-  virtual const char* what() const throw() {
+  ~TokenizeError() noexcept {}
+  virtual const char* what() const noexcept {
     return msg_.c_str();
   }
  private:


### PR DESCRIPTION
`throw()` is deprecated and has been since C++11. Replace with `noexcept`.