### PR TITLE
fix: missing #include <exception> for exception handling

### DIFF
--- a/include/dmlc/common.h
+++ b/include/dmlc/common.h
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <mutex>
 #include <utility>
+#include <exception>
 #include "./logging.h"
 
 namespace dmlc {


### PR DESCRIPTION
Some platforms might fail to compile due to the missing <exception> header for exception handling.