### PR TITLE
Remove compiler flags, fix build warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,12 +207,6 @@ else()
     target_compile_options(dmlc PRIVATE -msse2)
   endif()
   target_compile_options(dmlc PRIVATE -Wall -Wno-unknown-pragmas -fPIC)
-  if(CMAKE_BUILD_TYPE STREQUAL "DEBUG" OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-    target_compile_options(dmlc PRIVATE -g -O0)
-  else()
-    target_compile_options(dmlc PRIVATE -O3)
-  endif()
-
   target_compile_definitions(dmlc PUBLIC -DDMLC_USE_CXX11=1 -DDMLC_USE_CXX14=1)
 endif()
 

--- a/include/dmlc/concurrentqueue.h
+++ b/include/dmlc/concurrentqueue.h
@@ -158,11 +158,11 @@ struct thread_id_converter<thread_id_t> {
   typedef thread_id_numeric_size_t thread_id_hash_t;
     #endif
 
-  static thread_id_hash_t prehash(thread_id_t const &x) {
+  static thread_id_hash_t prehash(const thread_id_t &x) {
     #ifndef __APPLE__
     return std::hash<std::thread::id>()(x);
     #else
-    return *reinterpret_cast<thread_id_hash_t const *>(&x);
+    return *reinterpret_cast<const thread_id_hash_t *>(&x);
     #endif
   }
 };

--- a/include/dmlc/optional.h
+++ b/include/dmlc/optional.h
@@ -95,15 +95,9 @@ class optional {
   }
   /*! \brief move constructor: If other contains a value, then stored value is
    * direct-intialized with it. */
-  optional(optional &&other) noexcept(
-      std::is_nothrow_move_constructible<T>::value && std::is_nothrow_move_assignable<T>::value) {
-    if (!other.has_value()) {
-      reset();
-    } else if (has_value()) {
-      **this = std::move(*other);
-    } else {
-      new (&val) T(std::move(*other));
-      is_none = false;
+  optional(optional &&other) noexcept(std::is_nothrow_move_constructible<T>::value) {
+    if (other.has_value()) {
+      this->construct(std::move(*other));
     }
   }
   /*! \brief constructs an optional object that contains a value, initialized as
@@ -186,8 +180,16 @@ class optional {
   }
   /*! \brief swap two optional */
   void swap(optional<T> &other) {
-    std::swap(val, other.val);
-    std::swap(is_none, other.is_none);
+    if (this->has_value() && other.has_value()) {
+      using std::swap;  // Use ADL
+      swap(**this, *other);
+    } else if (this->has_value()) {
+      other.construct(std::move(**this));
+      this->reset();
+    } else if (other.has_value()) {
+      this->construct(std::move(*other));
+      other.reset();
+    }
   }
   /*! \brief set this object to hold value
    *  \param value the value to hold
@@ -214,7 +216,7 @@ class optional {
    *         optional<T> x = nullopt;
    */
   optional<T> &operator=(nullopt_t) {
-    (optional<T>()).swap(*this);
+    this->reset();
     return *this;
   }
   /*! \brief non-const dereference operator */
@@ -273,7 +275,7 @@ class optional {
   typename std::aligned_storage<sizeof(T), alignof(T)>::type val;
 
   template <typename... Args>
-  void construct(Args &&...args) noexcept {
+  void construct(Args &&...args) noexcept(std::is_nothrow_constructible<T, Args &&...>::value) {
     new (std::addressof(val)) T(std::forward<Args>(args)...);
     is_none = false;
   }

--- a/src/data/text_parser.h
+++ b/src/data/text_parser.h
@@ -53,8 +53,7 @@ class TextParserBase : public ParserImpl<IndexType, DType> {
    * \param end end of buffer
    */
   virtual void ParseBlock(
-      const char *begin, const char *end, RowBlockContainer<IndexType, DType> *out)
-      = 0;
+      const char *begin, const char *end, RowBlockContainer<IndexType, DType> *out) = 0;
   /*!
    * \brief read in next several blocks of data
    * \param data vector of data to be returned


### PR DESCRIPTION
- Really, there's no reason for a project CMake script to inject `-g` or `-O3`.
- Fix the maybe uninitialized value error in the `optional` class.